### PR TITLE
Fix comment and pass lint

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -154,7 +154,7 @@ app.whenReady().then(() => {
   ipcMain.handle('create-new-project', async (_, projectName) => {
   log(`Creating new project: ${projectName}`);
   try {
-    const projectPath = path.join(getProjectsPath(), projectName); // <-- FIXED
+    const projectPath = path.join(getProjectsPath(), projectName);
     if (!fs.existsSync(projectPath)) {
       fs.mkdirSync(projectPath, { recursive: true });
       updateProjectMetadata(projectName);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,13 @@
 import './App.css';
-import leaderLogo from './assets/LeaderPass-Logo-white.png';
+import _leaderLogo from './assets/LeaderPass-Logo-white.png';
 import { useState } from 'react';
 import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
 import mammoth from 'mammoth';
 
 function App() {
-  const [selectedScript, setSelectedScript] = useState(null);
-  const [selectedProject, setSelectedProject] = useState(null);
+  const [_selectedScript, setSelectedScript] = useState(null);
+  const [_selectedProject, setSelectedProject] = useState(null);
   const [scriptHtml, setScriptHtml] = useState(null);
 
   const handleScriptSelect = async (projectName, scriptName) => {


### PR DESCRIPTION
## Summary
- remove stray comment in Electron main process
- rename unused variables with underscores to satisfy lint rules

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bed7f1d14832192d802daa721a8cb