### PR TITLE
Fix select-files handler

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -170,6 +170,15 @@ app.whenReady().then(() => {
   }
 });
 
+  ipcMain.handle('select-files', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog({
+      properties: ['openFile', 'multiSelections'],
+      filters: [{ name: 'Word Docs', extensions: ['docx'] }],
+    });
+
+    return canceled ? null : filePaths;
+  });
+
 ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) => {
   log(`Importing scripts to project: ${projectName}`);
   if (!Array.isArray(filePaths) || !filePaths.length || !projectName) {
@@ -199,17 +208,8 @@ ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) =>
     }
   }
 
-  ipcMain.handle('select-files', async () => {
-  const { canceled, filePaths } = await dialog.showOpenDialog({
-    properties: ['openFile', 'multiSelections'],
-    filters: [{ name: 'Word Docs', extensions: ['docx'] }],
-  });
-
-  return canceled ? null : filePaths;
-});
-
   updateProjectMetadata(projectName);
-})
+});
 
   ipcMain.handle('get-projects', () => {
     log('Fetching list of projects');

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -1,11 +1,9 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 
 function FileManager({ onScriptSelect }) {
   const [projects, setProjects] = useState([]);
   const [newProjectName, setNewProjectName] = useState('');
   const [showNewProjectInput, setShowNewProjectInput] = useState(false);
-  const fileInputRef = useRef(null);
-  const [importTarget, setImportTarget] = useState(null);
 
   useEffect(() => {
     loadProjects();
@@ -29,21 +27,12 @@ function FileManager({ onScriptSelect }) {
     }
   };
 
-  const handleImportClick = (projectName) => {
-    setImportTarget(projectName);
-    fileInputRef.current.click();
-  };
+  const handleImportClick = async (projectName) => {
+    const filePaths = await window.electronAPI.selectFiles();
+    if (!filePaths) return;
 
-  const handleFileChange = async (event) => {
-    const files = Array.from(event.target.files);
-    if (!files.length || !importTarget) return;
-
-    const filePaths = files.map((file) => file.path);
-    await window.electronAPI.importScriptsToProject(filePaths, importTarget);
+    await window.electronAPI.importScriptsToProject(filePaths, projectName);
     await loadProjects();
-
-    setImportTarget(null);
-    event.target.value = null; // reset input
   };
 
   return (
@@ -64,15 +53,6 @@ function FileManager({ onScriptSelect }) {
           <button onClick={handleNewProject}>Create</button>
         </div>
       )}
-
-      <input
-        type="file"
-        accept=".docx"
-        ref={fileInputRef}
-        style={{ display: 'none' }}
-        multiple
-        onChange={handleFileChange}
-      />
 
       <div className="file-manager-list">
         {projects.map((project) => (


### PR DESCRIPTION
## Summary
- move 'select-files' registration outside import handler
- ensure import handler closes properly

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bf2adca3c8321a33a088b0e979be1