### PR TITLE
Fix script loading via IPC

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const path = require('path');
 const fs = require('fs');
+const mammoth = require('mammoth');
 
 let mainWindow;
 
@@ -221,6 +222,18 @@ ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) =>
     log(`Fetching scripts for project: ${projectName}`);
     const folderPath = path.join(getProjectsPath(), projectName);
     return fs.readdirSync(folderPath).filter((f) => f.endsWith('.docx'));
+  });
+
+  ipcMain.handle('load-script', async (_, projectName, scriptName) => {
+    const scriptPath = path.join(getProjectsPath(), projectName, scriptName);
+    log(`Loading script: ${scriptPath}`);
+    try {
+      const result = await mammoth.convertToHtml({ path: scriptPath });
+      return result.value;
+    } catch (err) {
+      error('Failed to load script:', err);
+      return null;
+    }
   });
 });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -17,4 +17,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAllProjectsWithScripts: () =>
     ipcRenderer.invoke('get-all-projects-with-scripts'),
   selectFiles: () => ipcRenderer.invoke('select-files'),
+  loadScript: (projectName, scriptName) =>
+    ipcRenderer.invoke('load-script', projectName, scriptName),
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,7 @@
 import './App.css';
-import _leaderLogo from './assets/LeaderPass-Logo-white.png';
 import { useState } from 'react';
 import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
-import mammoth from 'mammoth';
 
 function App() {
   const [_selectedScript, setSelectedScript] = useState(null);
@@ -14,11 +12,8 @@ function App() {
     setSelectedProject(projectName);
     setSelectedScript(scriptName);
     try {
-      const scriptPath = `C:/Users/LeaderPass 1/LeaderPrompt/projects/${projectName}/${scriptName}`;
-      const response = await fetch(`file://${scriptPath}`);
-      const arrayBuffer = await response.arrayBuffer();
-      const result = await mammoth.convertToHtml({ arrayBuffer });
-      setScriptHtml(result.value);
+      const html = await window.electronAPI.loadScript(projectName, scriptName);
+      setScriptHtml(html);
     } catch (err) {
       console.error('Failed to load script:', err);
     }


### PR DESCRIPTION
## Summary
- add `mammoth` in electron main process
- provide IPC handler `load-script` for reading docx and returning HTML
- expose `loadScript` in preload
- update React app to load scripts via IPC instead of `fetch`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686bf625ef108321a9167527029aeae5