### PR TITLE
Implement live editing for teleprompter

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -6,8 +6,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Prompter & project controls
   openPrompter: (html) => ipcRenderer.send('open-prompter', html),
   onScriptLoaded: (callback) => ipcRenderer.on('load-script', (_, data) => callback(data)),
+  onScriptUpdated: (callback) => ipcRenderer.on('update-script', (_, data) => callback(data)),
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),
   createNewProject: (name) => ipcRenderer.invoke('create-new-project', name),
+
+  // Live update support
+  sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
 
   // Script import/load controls
   importScriptsToProject: (filePaths, projectName) =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,11 @@ function App() {
     }
   };
 
+  const handleScriptEdit = (html) => {
+    setScriptHtml(html);
+    window.electronAPI.sendUpdatedScript(html);
+  };
+
   return (
     <div className="main-layout">
       <div className="left-panel">
@@ -35,6 +40,7 @@ function App() {
           scriptHtml={scriptHtml}
           showLogo={!scriptHtml}
           onSend={handleSendToPrompter}
+          onEdit={handleScriptEdit}
         />
       </div>
     </div>

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -12,6 +12,9 @@ function Prompter() {
     window.electronAPI.onScriptLoaded((html) => {
       setContent(html)
     })
+    window.electronAPI.onScriptUpdated((html) => {
+      setContent(html)
+    })
   }, [])
 
   useEffect(() => {

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -47,3 +47,10 @@
 .lets-go-button:hover {
   background-color: #1466b8;
 }
+
+.script-content {
+  outline: none;
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 2rem;
+}

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -1,7 +1,7 @@
 import './ScriptViewer.css';
 import leaderLogo from './assets/LeaderPass-Logo-white.png';
 
-function ScriptViewer({ scriptHtml, showLogo, onSend }) {
+function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
   return (
     <div className="script-viewer">
       {showLogo ? (
@@ -12,6 +12,8 @@ function ScriptViewer({ scriptHtml, showLogo, onSend }) {
         <>
           <div
             className="script-content"
+            contentEditable
+            onInput={(e) => onEdit(e.currentTarget.innerHTML)}
             dangerouslySetInnerHTML={{ __html: scriptHtml }}
           />
           <div className="send-button-wrapper">


### PR DESCRIPTION
## Summary
- make teleprompter window accessible via IPC to push updates
- expose `sendUpdatedScript`/`onScriptUpdated` in the preload API
- edit scripts in `ScriptViewer` using a `contentEditable` div
- keep `scriptHtml` state in `App` and push updates on input
- update prompter window reactively when script changes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bf9a021308321bb0f28852e8dca93