### PR TITLE
Add script deletion feature

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -235,6 +235,21 @@ ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) =>
       return null;
     }
   });
+
+  ipcMain.handle('delete-script', async (_, projectName, scriptName) => {
+    const scriptPath = path.join(getProjectsPath(), projectName, scriptName);
+    log(`Deleting script: ${scriptPath}`);
+    try {
+      if (fs.existsSync(scriptPath) && scriptPath.endsWith('.docx')) {
+        fs.unlinkSync(scriptPath);
+        return true;
+      }
+      return false;
+    } catch (err) {
+      error('Failed to delete script:', err);
+      return false;
+    }
+  });
 });
 
 // --- App Exit Handler ---

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -19,4 +19,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   selectFiles: () => ipcRenderer.invoke('select-files'),
   loadScript: (projectName, scriptName) =>
     ipcRenderer.invoke('load-script', projectName, scriptName),
+  deleteScript: (projectName, scriptName) =>
+    ipcRenderer.invoke('delete-script', projectName, scriptName),
 });

--- a/src/App.css
+++ b/src/App.css
@@ -145,18 +145,32 @@ body {
 
 .project-group li {
   margin-bottom: 4px;
+  display: flex;
+  align-items: center;
 }
 
-.project-group li button {
+.script-button {
+  flex-grow: 1;
   background: none;
   border: none;
   color: #1f80e0;
   text-align: left;
   padding: 4px 0;
   cursor: pointer;
-  width: 100%;
 }
 
-.project-group li button:hover {
+.script-button:hover {
+  text-decoration: underline;
+}
+
+.delete-button {
+  background: none;
+  border: none;
+  color: #e04040;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.delete-button:hover {
   text-decoration: underline;
 }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -35,6 +35,15 @@ function FileManager({ onScriptSelect }) {
     await loadProjects();
   };
 
+  const handleDeleteScript = async (projectName, scriptName) => {
+    const success = await window.electronAPI.deleteScript(projectName, scriptName);
+    if (success) {
+      loadProjects();
+    } else {
+      alert('Failed to delete script');
+    }
+  };
+
   return (
     <div className="file-manager">
       <div className="file-manager-header">
@@ -63,9 +72,18 @@ function FileManager({ onScriptSelect }) {
             </div>
             <ul>
               {project.scripts.map((script) => (
-                <li key={script}>
-                  <button onClick={() => onScriptSelect(project.name, script)}>
+                <li key={script} className="script-item">
+                  <button
+                    className="script-button"
+                    onClick={() => onScriptSelect(project.name, script)}
+                  >
                     {script.replace(/\.[^/.]+$/, '')}
+                  </button>
+                  <button
+                    className="delete-button"
+                    onClick={() => handleDeleteScript(project.name, script)}
+                  >
+                    ✖
                   </button>
                 </li>
               ))}
@@ -78,3 +96,4 @@ function FileManager({ onScriptSelect }) {
 }
 
 export default FileManager;
+


### PR DESCRIPTION
## Summary
- add `delete-script` handler in main process
- expose `deleteScript` to renderer
- add delete controls in FileManager and refresh list
- style script delete button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686bf9a918b08321947fe0e47ff7876f