### PR TITLE
Add script update listener in preload

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Electron API
+
+The preload script exposes an `electronAPI` object on `window` for renderer processes. Alongside other helpers, you can listen for live script updates with:
+
+```javascript
+window.electronAPI.onScriptUpdated((html) => {
+  // handle updated HTML
+});
+```
+
+This pairs with `sendUpdatedScript(html)` to keep the prompter view in sync.

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -3,18 +3,19 @@ const { contextBridge, ipcRenderer } = require('electron');
 console.log('[PRELOAD] Preload script loaded ✅');
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Prompter & project controls
+  // Prompter controls
   openPrompter: (html) => ipcRenderer.send('open-prompter', html),
-  onScriptLoaded: (callback) => ipcRenderer.on('load-script', (_, data) => callback(data)),
+  onScriptLoaded: (callback) =>
+    ipcRenderer.on('load-script', (_, data) => callback(data)),
+  onScriptUpdated: (cb) =>
+    ipcRenderer.on('update-script', (_, data) => cb(data)),
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
-=======
+
+  // Project management
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),
   createNewProject: (name) => ipcRenderer.invoke('create-new-project', name),
   renameProject: (oldName, newName) =>
     ipcRenderer.invoke('rename-project', oldName, newName),
-
-  // Live update support
-  sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
 
   // Script import/load controls
   importScriptsToProject: (filePaths, projectName) =>

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -55,6 +55,13 @@ function FileManager({ onScriptSelect }) {
     await loadProjects();
   };
 
+  const handleDeleteScript = async (projectName, scriptName) => {
+    if (!window.confirm('Delete this script?')) return;
+    const success = await window.electronAPI.deleteScript(projectName, scriptName);
+    if (!success) alert('Failed to delete script');
+    await loadProjects();
+  };
+
   return (
     <div className="file-manager">
       <div className="file-manager-header">

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -2,7 +2,7 @@ import './ScriptViewer.css';
 import leaderLogo from './assets/LeaderPass-Logo-white.png';
 import { useEffect } from 'react';
 
-function ScriptViewer({ scriptHtml, showLogo, onSend }) {
+function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
   useEffect(() => {
     if (scriptHtml) {
       window.electronAPI.sendUpdatedScript(scriptHtml);


### PR DESCRIPTION
## Summary
- clean up preload script merge artifacts
- expose `onScriptUpdated` API for renderer processes
- fix FileManager delete logic and ScriptViewer props
- document new preload API

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ce006bc83218fbac25f3db3a54f