### PR TITLE
Implement uncontrolled editing for script viewer

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -5,18 +5,13 @@ console.log('[PRELOAD] Preload script loaded ✅');
 contextBridge.exposeInMainWorld('electronAPI', {
   // Prompter controls
   openPrompter: (html) => ipcRenderer.send('open-prompter', html),
-<<<<<<< HEAD
-  onScriptLoaded: (callback) => ipcRenderer.on('load-script', (_, data) => callback(data)),
-  onScriptUpdated: (callback) => ipcRenderer.on('update-script', (_, data) => callback(data)),
-=======
   onScriptLoaded: (callback) =>
     ipcRenderer.on('load-script', (_, data) => callback(data)),
-  onScriptUpdated: (cb) =>
-    ipcRenderer.on('update-script', (_, data) => cb(data)),
+  onScriptUpdated: (callback) =>
+    ipcRenderer.on('update-script', (_, data) => callback(data)),
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
 
   // Project management
->>>>>>> bb94cead8c26cb9a8b3cbdf5801d05e5971c09ce
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),
   createNewProject: (name) => ipcRenderer.invoke('create-new-project', name),
   renameProject: (oldName, newName) =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,6 @@ function App() {
 
   const handleScriptEdit = (html) => {
     setScriptHtml(html);
-    window.electronAPI.sendUpdatedScript(html);
   };
 
   return (

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -1,13 +1,22 @@
 import './ScriptViewer.css';
 import leaderLogo from './assets/LeaderPass-Logo-white.png';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
+  const contentRef = useRef(null);
+
   useEffect(() => {
-    if (scriptHtml) {
+    if (contentRef.current && scriptHtml) {
+      contentRef.current.innerHTML = scriptHtml;
       window.electronAPI.sendUpdatedScript(scriptHtml);
     }
   }, [scriptHtml]);
+
+  const handleBlur = () => {
+    if (contentRef.current) {
+      onEdit(contentRef.current.innerHTML);
+    }
+  };
   
   return (
     <div className="script-viewer">
@@ -18,10 +27,10 @@ function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
       ) : (
         <>
           <div
+            ref={contentRef}
             className="script-content"
             contentEditable
-            onInput={(e) => onEdit(e.currentTarget.innerHTML)}
-            dangerouslySetInnerHTML={{ __html: scriptHtml }}
+            onBlur={handleBlur}
           />
           <div className="send-button-wrapper">
             <button className="send-button" onClick={onSend}>


### PR DESCRIPTION
## Summary
- control script editing with a DOM ref instead of `onInput`
- only update script HTML in App when blur/save occurs
- clean up preload script merge markers

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d2ffcbf248321a6fc10132ba41ad4