### PR TITLE
Add staging area for teleprompter scripts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -185,3 +185,14 @@ body {
 .delete-button:hover {
   text-decoration: underline;
 }
+
+.script-item.loaded .script-button {
+  font-weight: bold;
+  color: #fff;
+}
+
+.loaded-indicator {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  color: #1f80e0;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,10 @@ import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
 
 function App() {
-  const [_selectedScript, setSelectedScript] = useState(null);
-  const [_selectedProject, setSelectedProject] = useState(null);
+  const [selectedScript, setSelectedScript] = useState(null);
+  const [selectedProject, setSelectedProject] = useState(null);
+  const [loadedScript, setLoadedScript] = useState(null);
+  const [loadedProject, setLoadedProject] = useState(null);
   const [scriptHtml, setScriptHtml] = useState(null);
   const [leftWidth, setLeftWidth] = useState(300);
   const leftRef = useRef(null);
@@ -52,17 +54,29 @@ function App() {
   const handleSendToPrompter = () => {
     if (scriptHtml) {
       window.electronAPI.openPrompter(scriptHtml);
+      setLoadedProject(selectedProject);
+      setLoadedScript(selectedScript);
     }
   };
 
   const handleScriptEdit = (html) => {
     setScriptHtml(html);
+    if (
+      selectedProject === loadedProject &&
+      selectedScript === loadedScript
+    ) {
+      window.electronAPI.sendUpdatedScript(html);
+    }
   };
 
   return (
     <div className="main-layout">
       <div className="left-panel" ref={leftRef} style={{ width: leftWidth }}>
-        <FileManager onScriptSelect={handleScriptSelect} />
+        <FileManager
+          onScriptSelect={handleScriptSelect}
+          loadedProject={loadedProject}
+          loadedScript={loadedScript}
+        />
       </div>
       <div className="divider" onMouseDown={startDrag} />
       <div className="right-panel">

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-function FileManager({ onScriptSelect }) {
+function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
   const [projects, setProjects] = useState([]);
   const [newProjectName, setNewProjectName] = useState('');
   const [showNewProjectInput, setShowNewProjectInput] = useState(false);
@@ -103,22 +103,30 @@ function FileManager({ onScriptSelect }) {
               )}
             </div>
             <ul>
-              {project.scripts.map((script) => (
-                <li key={script} className="script-item">
-                  <button
-                    className="script-button"
-                    onClick={() => onScriptSelect(project.name, script)}
+              {project.scripts.map((script) => {
+                const isLoaded =
+                  loadedProject === project.name && loadedScript === script;
+                return (
+                  <li
+                    key={script}
+                    className={`script-item${isLoaded ? ' loaded' : ''}`}
                   >
-                    {script.replace(/\.[^/.]+$/, '')}
-                  </button>
-                  <button
-                    className="delete-button"
-                    onClick={() => handleDeleteScript(project.name, script)}
-                  >
-                    ✖
-                  </button>
-                </li>
-              ))}
+                    <button
+                      className="script-button"
+                      onClick={() => onScriptSelect(project.name, script)}
+                    >
+                      {script.replace(/\.[^/.]+$/, '')}
+                    </button>
+                    {isLoaded && <span className="loaded-indicator">(loaded)</span>}
+                    <button
+                      className="delete-button"
+                      onClick={() => handleDeleteScript(project.name, script)}
+                    >
+                      ✖
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         ))}

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -8,7 +8,6 @@ function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
   useEffect(() => {
     if (contentRef.current && scriptHtml) {
       contentRef.current.innerHTML = scriptHtml;
-      window.electronAPI.sendUpdatedScript(scriptHtml);
     }
   }, [scriptHtml]);
 


### PR DESCRIPTION
## Summary
- keep editor updates local unless the script is loaded in the prompter
- track which script is loaded and mark it in the file manager
- indicate loaded scripts via new CSS styles
- revert `.gitignore` change

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d3638299c832196184140fe6be90a