### PR TITLE
Remove redundant projectsDir from electron main file

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -16,7 +16,6 @@ const error = (...args) => console.error('[ERROR]', ...args);
 const getUserDataPath = () => path.join(app.getPath('home'), 'LeaderPrompt');
 const getProjectsPath = () => path.join(getUserDataPath(), 'projects');
 const getProjectMetadataPath = () => path.join(getUserDataPath(), 'projects.json');
-const projectsDir = path.join(app.getPath('userData'), 'projects');
 
 function ensureDirectories() {
   if (!fs.existsSync(getUserDataPath())) {
@@ -34,10 +33,6 @@ function ensureDirectories() {
     log('Created projects.json metadata file');
   }
 
-  if (!fs.existsSync(projectsDir)) {
-    fs.mkdirSync(projectsDir, { recursive: true });
-    log('Created sandboxed projects directory (userData path)');
-  }
 }
 
 function getProjectMetadata() {


### PR DESCRIPTION
## Summary
- clean up electron/main.cjs by removing the unused `projectsDir` variable and its directory creation step

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d3edb99848321a8c980b1dcccc2b9