### PR TITLE
Add IPC listener cleanup in Prompter

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -9,12 +9,20 @@ function Prompter() {
   const containerRef = useRef(null)
 
   useEffect(() => {
-    window.electronAPI.onScriptLoaded((html) => {
+    const handleLoaded = (html) => {
       setContent(html)
-    })
-    window.electronAPI.onScriptUpdated((html) => {
+    }
+    const handleUpdated = (html) => {
       setContent(html)
-    })
+    }
+
+    window.electronAPI.onScriptLoaded(handleLoaded)
+    window.electronAPI.onScriptUpdated(handleUpdated)
+
+    return () => {
+      window.ipcRenderer?.removeListener('load-script', handleLoaded)
+      window.ipcRenderer?.removeListener('update-script', handleUpdated)
+    }
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- unregister IPC listeners when Prompter unmounts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d3edc897c832183914df7212bb174