### PR TITLE
Stop dev server on app exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "build": "vite build",
   "lint": "eslint .",
   "preview": "vite preview",
-  "electron-dev": "concurrently \"npm run dev\" \"electron electron/main.cjs\""
+  "electron-dev": "electron electron/main.cjs"
   },
   "dependencies": {
     "mammoth": "^1.9.1",


### PR DESCRIPTION
## Summary
- spawn the Vite dev server from `electron/main.cjs`
- stop the dev server when the Electron app exits
- update the dev script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d455b94948321a04c69fc6938722f