### PR TITLE
Add header with logo and editor title to ScriptViewer

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -2,10 +2,25 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   height: 100%;
   background-color: #000;
   color: #fff;
+}
+
+.viewer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.header-logo {
+  width: 120px;
+}
+
+.header-title {
+  margin: 0;
+  font-size: 1.5rem;
 }
 
 .script-viewer-content {
@@ -19,17 +34,14 @@
   margin: 0 auto;
 }
 
-.logo-container {
+
+.load-placeholder {
+  flex-grow: 1;
   display: flex;
   justify-content: center;
   align-items: center;
-  flex-grow: 1;
-  padding-top: 40px;
-}
-
-.script-viewer-logo {
-  max-width: 200px;
-  opacity: 0.3;
+  font-size: 1.2rem;
+  color: #aaa;
 }
 
 .lets-go-button {

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -18,27 +18,29 @@ function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
   };
   
   return (
-    <div className="script-viewer">
-      {showLogo ? (
-        <div className="logo-wrapper">
-          <img src={leaderLogo} alt="LeaderPrompt Logo" className="viewer-logo" />
+      <div className="script-viewer">
+        <div className="viewer-header">
+          {!showLogo && <h2 className="header-title">Script Editor</h2>}
+          <img src={leaderLogo} alt="LeaderPrompt Logo" className="header-logo" />
         </div>
-      ) : (
-        <>
-          <div
-            ref={contentRef}
-            className="script-content"
-            contentEditable
-            onBlur={handleBlur}
-          />
-          <div className="send-button-wrapper">
-            <button className="send-button" onClick={onSend}>
-              Let&apos;s Go!
-            </button>
-          </div>
-        </>
-      )}
-    </div>
+        {showLogo ? (
+          <div className="load-placeholder">Please load a script</div>
+        ) : (
+          <>
+            <div
+              ref={contentRef}
+              className="script-content"
+              contentEditable
+              onBlur={handleBlur}
+            />
+            <div className="send-button-wrapper">
+              <button className="send-button" onClick={onSend}>
+                Let&apos;s Go!
+              </button>
+            </div>
+          </>
+        )}
+      </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add header to ScriptViewer with top-right logo and 'Script Editor' title
- show centered placeholder when no script is loaded

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d4ace7bb08321ae6c9bef59ce4792