### PR TITLE
Center placeholder and add close button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,10 @@ function App() {
     }
   };
 
+  const handleCloseScript = () => {
+    setScriptHtml(null);
+  };
+
   return (
     <div className="main-layout">
       <div className="left-panel" ref={leftRef} style={{ width: leftWidth }}>
@@ -85,6 +89,7 @@ function App() {
           showLogo={!scriptHtml}
           onSend={handleSendToPrompter}
           onEdit={handleScriptEdit}
+          onClose={handleCloseScript}
         />
       </div>
     </div>

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -2,10 +2,32 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   height: 100%;
   background-color: #000;
   color: #fff;
+}
+
+.viewer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.header-logo {
+  width: 120px;
+  margin-left: auto;
+}
+
+.header-title {
+  margin: 0;
+  font-size: 1.5rem;
 }
 
 .script-viewer-content {
@@ -19,17 +41,28 @@
   margin: 0 auto;
 }
 
-.logo-container {
+
+.load-placeholder {
+  flex-grow: 1;
   display: flex;
   justify-content: center;
   align-items: center;
-  flex-grow: 1;
-  padding-top: 40px;
+  text-align: center;
+  font-size: 1.2rem;
+  color: #aaa;
 }
 
-.script-viewer-logo {
-  max-width: 200px;
-  opacity: 0.3;
+.close-button {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.9rem;
+}
+
+.close-button:hover {
+  text-decoration: underline;
 }
 
 .lets-go-button {

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -2,7 +2,7 @@ import './ScriptViewer.css';
 import leaderLogo from './assets/LeaderPass-Logo-white.png';
 import { useEffect, useRef } from 'react';
 
-function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
+function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit, onClose }) {
   const contentRef = useRef(null);
 
   useEffect(() => {
@@ -18,27 +18,36 @@ function ScriptViewer({ scriptHtml, showLogo, onSend, onEdit }) {
   };
   
   return (
-    <div className="script-viewer">
-      {showLogo ? (
-        <div className="logo-wrapper">
-          <img src={leaderLogo} alt="LeaderPrompt Logo" className="viewer-logo" />
-        </div>
-      ) : (
-        <>
-          <div
-            ref={contentRef}
-            className="script-content"
-            contentEditable
-            onBlur={handleBlur}
-          />
-          <div className="send-button-wrapper">
-            <button className="send-button" onClick={onSend}>
-              Let&apos;s Go!
-            </button>
+      <div className="script-viewer">
+        <div className="viewer-header">
+          <div className="header-left">
+            {!showLogo && <h2 className="header-title">Script Editor</h2>}
+            {!showLogo && (
+              <button className="close-button" onClick={onClose}>
+                Close
+              </button>
+            )}
           </div>
-        </>
-      )}
-    </div>
+          <img src={leaderLogo} alt="LeaderPrompt Logo" className="header-logo" />
+        </div>
+        {showLogo ? (
+          <div className="load-placeholder">Please load a script</div>
+        ) : (
+          <>
+            <div
+              ref={contentRef}
+              className="script-content"
+              contentEditable
+              onBlur={handleBlur}
+            />
+            <div className="send-button-wrapper">
+              <button className="send-button" onClick={onSend}>
+                Let&apos;s Go!
+              </button>
+            </div>
+          </>
+        )}
+      </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- center `Please load a script` placeholder
- ensure header logo stays right-aligned
- add close button in ScriptViewer

## Testing
- `npm install`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d4ace7bb08321ae6c9bef59ce4792