### PR TITLE
Fix missing closing brace in ScriptViewer.css

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -64,6 +64,7 @@
 
 .close-button:hover {
   text-decoration: underline;
+}
 
 .lets-go-button {
   margin: 1rem auto 2rem auto;


### PR DESCRIPTION
## Summary
- close `.close-button:hover` rule in `ScriptViewer.css`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d536493808321a7f09173a2bb0e57