### PR TITLE
Add Metropolis font

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Metropolis:wght@400;700&display=swap" rel="stylesheet" />
     <title>LeaderPrompt</title>
   </head>
   <body>

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -86,4 +86,5 @@
   flex-grow: 1;
   overflow-y: auto;
   padding: 2rem;
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Metropolis', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
## Summary
- load Metropolis from Google Fonts
- set the default font to Metropolis
- keep Prompter and ScriptViewer default fonts

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d536e31288321be4ae84a6847ec6a