### PR TITLE
Add accent color var and soften dark theme

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,11 +1,15 @@
 /* App.css */
 
+:root {
+  --accent-color: #1f80e0;
+}
+
 body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
-  background-color: #000;
-  color: #fff;
+  background-color: #1e1e1e;
+  color: #e0e0e0;
 }
 
 .main-layout {
@@ -45,8 +49,8 @@ body {
 .import-button {
   padding: 12px 24px;
   font-size: 16px;
-  background-color: #1f80e0;
-  color: white;
+  background-color: var(--accent-color);
+  color: #e0e0e0;
   border: none;
   border-radius: 6px;
   cursor: pointer;
@@ -78,7 +82,7 @@ body {
 .file-manager-header button {
   padding: 6px 12px;
   background-color: #333;
-  color: white;
+  color: #e0e0e0;
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -99,7 +103,7 @@ body {
   padding: 0.25rem;
   background-color: #222;
   border: 1px solid #444;
-  color: white;
+  color: #e0e0e0;
   border-radius: 4px;
 }
 
@@ -107,7 +111,7 @@ body {
   padding: 0.25rem 0.5rem;
   background-color: #444;
   border: none;
-  color: white;
+  color: #e0e0e0;
   border-radius: 4px;
   cursor: pointer;
 }
@@ -137,7 +141,7 @@ body {
 .project-header button {
   background: #333;
   border: none;
-  color: white;
+  color: #e0e0e0;
   padding: 2px 6px;
   font-size: 14px;
   border-radius: 4px;
@@ -164,7 +168,7 @@ body {
   flex-grow: 1;
   background: none;
   border: none;
-  color: #1f80e0;
+  color: var(--accent-color);
   text-align: left;
   padding: 4px 0;
   cursor: pointer;
@@ -188,11 +192,11 @@ body {
 
 .script-item.loaded .script-button {
   font-weight: bold;
-  color: #fff;
+  color: #e0e0e0;
 }
 
 .loaded-indicator {
   margin-left: 0.5rem;
   font-size: 0.8rem;
-  color: #1f80e0;
+  color: var(--accent-color);
 }

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -1,8 +1,8 @@
 .prompter-container {
   height: 100vh;
   overflow-y: scroll;
-  background: black;
-  color: white;
+  background: #1e1e1e;
+  color: #e0e0e0;
   font-size: 2rem;
   line-height: 1.6;
   font-family: 'Georgia', serif;
@@ -16,6 +16,6 @@
   background: rgba(0,0,0,0.6);
   padding: 1rem;
   border-radius: 8px;
-  color: white;
+  color: #e0e0e0;
   font-size: 14px;
 }

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -3,8 +3,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background-color: #000;
-  color: #fff;
+  background-color: #1e1e1e;
+  color: #e0e0e0;
 }
 
 .viewer-header {
@@ -34,7 +34,7 @@
   flex-grow: 1;
   overflow-y: auto;
   padding: 2rem;
-  background-color: #000;
+  background-color: #1e1e1e;
   line-height: 1.6;
   font-size: 16px;
   max-width: 800px;
@@ -56,7 +56,7 @@
 .close-button {
   background: none;
   border: none;
-  color: #fff;
+  color: #e0e0e0;
   cursor: pointer;
   padding: 0.25rem 0.5rem;
   font-size: 0.9rem;
@@ -64,13 +64,14 @@
 
 .close-button:hover {
   text-decoration: underline;
+}
 
 .lets-go-button {
   margin: 1rem auto 2rem auto;
   padding: 12px 24px;
   font-size: 16px;
-  background-color: #1f80e0;
-  color: white;
+  background-color: var(--accent-color);
+  color: #e0e0e0;
   border: none;
   border-radius: 6px;
   cursor: pointer;

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,9 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #e0e0e0;
+  background-color: #1e1e1e;
+  --accent-color: #1f80e0;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary
- introduce `--accent-color` custom property
- soften background and text colors
- use accent color variable for buttons and indicators

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d536cc3388321bd04d30262415810