### PR TITLE
Add script rename via IPC and UI

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -314,6 +314,26 @@ ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) =>
     }
   });
 
+  ipcMain.handle('rename-script', async (_, projectName, oldName, newName) => {
+    log(`Renaming script in ${projectName}: ${oldName} -> ${newName}`);
+    if (!projectName || !oldName || !newName || oldName === newName) return false;
+    try {
+      const oldPath = path.join(getProjectsPath(), projectName, oldName);
+      const finalNew = newName.endsWith('.docx') ? newName : `${newName}.docx`;
+      const newPath = path.join(getProjectsPath(), projectName, finalNew);
+      if (!fs.existsSync(oldPath) || fs.existsSync(newPath)) {
+        error('Script rename failed: source missing or destination exists');
+        return false;
+      }
+      fs.renameSync(oldPath, newPath);
+      log('Script rename complete');
+      return true;
+    } catch (err) {
+      error('Failed to rename script:', err);
+      return false;
+    }
+  });
+
   ipcMain.handle('delete-script', async (_, projectName, scriptName) => {
     const scriptPath = path.join(getProjectsPath(), projectName, scriptName);
     log(`Deleting script: ${scriptPath}`);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -29,4 +29,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('load-script', projectName, scriptName),
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
+  renameScript: (projectName, oldName, newName) =>
+    ipcRenderer.invoke('rename-script', projectName, oldName, newName),
 });

--- a/src/App.css
+++ b/src/App.css
@@ -204,3 +204,36 @@ body {
   font-size: 0.8rem;
   color: var(--accent-color);
 }
+
+.script-menu-button {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.script-menu {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #333;
+  border: 1px solid #555;
+  border-radius: 4px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+}
+
+.script-menu button {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  padding: 4px 8px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.script-menu button:hover {
+  background: #555;
+}

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -6,6 +6,9 @@ function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
   const [showNewProjectInput, setShowNewProjectInput] = useState(false);
   const [renaming, setRenaming] = useState(null);
   const [renameValue, setRenameValue] = useState('');
+  const [renamingScript, setRenamingScript] = useState(null);
+  const [renameScriptValue, setRenameScriptValue] = useState('');
+  const [openMenu, setOpenMenu] = useState(null);
 
   useEffect(() => {
     loadProjects();
@@ -55,7 +58,36 @@ function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
     await loadProjects();
   };
 
+  const startScriptRename = (projectName, scriptName) => {
+    setRenamingScript({ project: projectName, script: scriptName });
+    setRenameScriptValue(scriptName.replace(/\.[^/.]+$/, ''));
+    setOpenMenu(null);
+  };
+
+  const cancelScriptRename = () => {
+    setRenamingScript(null);
+    setRenameScriptValue('');
+  };
+
+  const confirmScriptRename = async (projectName, oldName) => {
+    if (!renameScriptValue.trim()) return;
+    const success = await window.electronAPI.renameScript(
+      projectName,
+      oldName,
+      renameScriptValue.trim()
+    );
+    if (!success) alert('Failed to rename script');
+    cancelScriptRename();
+    await loadProjects();
+  };
+
+  const toggleMenu = (projectName, scriptName) => {
+    const key = `${projectName}/${scriptName}`;
+    setOpenMenu(openMenu === key ? null : key);
+  };
+
   const handleDeleteScript = async (projectName, scriptName) => {
+    setOpenMenu(null);
     const deleted = await window.electronAPI.deleteScript(projectName, scriptName);
     if (!deleted) alert('Failed to delete script');
     await loadProjects();
@@ -106,24 +138,56 @@ function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
               {project.scripts.map((script) => {
                 const isLoaded =
                   loadedProject === project.name && loadedScript === script;
+                const menuKey = `${project.name}/${script}`;
+                const isRenaming =
+                  renamingScript &&
+                  renamingScript.project === project.name &&
+                  renamingScript.script === script;
                 return (
                   <li
                     key={script}
                     className={`script-item${isLoaded ? ' loaded' : ''}`}
+                    style={{ position: 'relative' }}
                   >
-                    <button
-                      className="script-button"
-                      onClick={() => onScriptSelect(project.name, script)}
-                    >
-                      {script.replace(/\.[^/.]+$/, '')}
-                    </button>
-                    {isLoaded && <span className="loaded-indicator">(loaded)</span>}
-                    <button
-                      className="delete-button"
-                      onClick={() => handleDeleteScript(project.name, script)}
-                    >
-                      ✖
-                    </button>
+                    {isRenaming ? (
+                      <>
+                        <input
+                          type="text"
+                          value={renameScriptValue}
+                          onChange={(e) => setRenameScriptValue(e.target.value)}
+                        />
+                        <button onClick={() => confirmScriptRename(project.name, script)}>
+                          Save
+                        </button>
+                        <button onClick={cancelScriptRename}>Cancel</button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          className="script-button"
+                          onClick={() => onScriptSelect(project.name, script)}
+                        >
+                          {script.replace(/\.[^/.]+$/, '')}
+                        </button>
+                        {isLoaded && <span className="loaded-indicator">(loaded)</span>}
+                        <button
+                          className="script-menu-button"
+                          onClick={() => toggleMenu(project.name, script)}
+                        >
+                          ⋮
+                        </button>
+                        {openMenu === menuKey && (
+                          <div className="script-menu">
+                            <button onClick={() => startScriptRename(project.name, script)}>
+                              Rename
+                            </button>
+                            <button onClick={() => handleDeleteScript(project.name, script)}>
+                              Delete
+                            </button>
+                          </div>
+                        )}
+                      </>
+                    )}
                   </li>
                 );
               })}


### PR DESCRIPTION
## Summary
- add `rename-script` IPC handler in `electron/main.cjs`
- expose `renameScript` in the preload bridge
- implement a hamburger menu for scripts with rename option

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d568652d483219e892360f874a389