### PR TITLE
Fix rename script extension bug

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -280,7 +280,11 @@ app.whenReady().then(() => {
     try {
       const base = path.join(getProjectsPath(), projectName);
       const oldPath = path.join(base, oldName);
-      const newPath = path.join(base, newName);
+      let targetName = newName;
+      if (!targetName.toLowerCase().endsWith('.docx')) {
+        targetName += '.docx';
+      }
+      const newPath = path.join(base, targetName);
       if (!fs.existsSync(oldPath) || fs.existsSync(newPath)) return false;
       fs.renameSync(oldPath, newPath);
       return true;

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -117,7 +117,11 @@ function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
 
   const confirmRenameScript = async (projectName, oldName) => {
     if (!renameValue.trim()) return;
-    const success = await window.electronAPI.renameScript(projectName, oldName, renameValue.trim());
+    let newName = renameValue.trim();
+    if (!newName.toLowerCase().endsWith('.docx')) {
+      newName += '.docx';
+    }
+    const success = await window.electronAPI.renameScript(projectName, oldName, newName);
     if (!success) alert('Failed to rename script');
     cancelRename();
     await loadProjects();


### PR DESCRIPTION
## Summary
- ensure script renaming keeps `.docx` in React UI
- guard Electron rename handler to enforce `.docx`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d6372d9408321866cd9a6a6a5d1b4