### PR TITLE
Simplify logging helper prefix

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -12,8 +12,8 @@ let prompterWindow;
 const prompterWindows = new Set();
 let viteProcess;
 
-const log = (...args) => console.log('[LOG]', ...args);
-const error = (...args) => console.error('[ERROR]', ...args);
+const log = (...args) => console.log(...args);
+const error = (...args) => console.error(...args);
 
 function startViteServer() {
   if (viteProcess || app.isPackaged) return;


### PR DESCRIPTION
## Summary
- simplify `log` and `error` helpers in `electron/main.cjs`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d6a6bb8e083219149636bf6a90be7