### PR TITLE
Reset loaded state when closing script

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,11 @@ function App() {
 
   const handleCloseScript = () => {
     setScriptHtml(null);
+    setSelectedProject(null);
+    setSelectedScript(null);
+    setLoadedProject(null);
+    setLoadedScript(null);
+    window.electronAPI.sendUpdatedScript('');
   };
 
   return (


### PR DESCRIPTION
## Summary
- reset selected and loaded script state when closing a script
- send a blank update to the prompter so the window is cleared

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d6d421ddc8321bce6b27f311e3a0e