### PR TITLE
Apply Metropolis font and update accent color

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,13 +1,13 @@
 /* App.css */
 
 :root {
-  --accent-color: #1f80e0;
+  --accent-color: #ffd166;
 }
 
 body {
   margin: 0;
   padding: 0;
-  font-family: sans-serif;
+  font-family: 'Metropolis', sans-serif;
   background-color: #1e1e1e;
   color: #e0e0e0;
 }
@@ -58,7 +58,7 @@ body {
 }
 
 .import-button:hover {
-  background-color: #1466b8;
+  background-color: var(--accent-color);
 }
 
 /* FileManager styles */
@@ -91,7 +91,7 @@ body {
 }
 
 .file-manager-header button:hover {
-  background-color: #1466b8;
+  background-color: var(--accent-color);
 }
 
 .new-project-input {
@@ -194,13 +194,15 @@ body {
   flex-grow: 1;
   background: none;
   border: none;
-  color: var(--accent-color);
+  color: #e0e0e0;
   text-align: left;
   padding: 4px 8px;
   cursor: pointer;
+  transition: color 0.2s;
 }
 
 .script-button:hover {
+  color: var(--accent-color);
   text-decoration: underline;
 }
 

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -5,7 +5,7 @@
   color: #e0e0e0;
   font-size: 2rem;
   line-height: 1.6;
-  font-family: 'Georgia', serif;
+  font-family: sans-serif;
 }
 
 .prompter-controls {

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -79,7 +79,7 @@
 }
 
 .lets-go-button:hover {
-  background-color: #1466b8;
+  background-color: var(--accent-color);
 }
 
 .script-content {
@@ -87,5 +87,5 @@
   flex-grow: 1;
   overflow-y: auto;
   padding: 2rem;
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: sans-serif;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   color-scheme: light dark;
   color: #e0e0e0;
   background-color: #1e1e1e;
-  --accent-color: #1f80e0;
+  --accent-color: #ffd166;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -16,11 +16,12 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #e0e0e0;
   text-decoration: inherit;
+  transition: color 0.2s;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--accent-color);
 }
 
 body {
@@ -48,7 +49,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--accent-color);
 }
 button:focus,
 button:focus-visible {
@@ -61,7 +62,7 @@ button:focus-visible {
     background-color: #ffffff;
   }
   a:hover {
-    color: #747bff;
+    color: var(--accent-color);
   }
   button {
     background-color: #f9f9f9;


### PR DESCRIPTION
## Summary
- use Metropolis for most text
- keep sans‑serif fonts in the viewer and prompter
- switch the accent color to `#ffd166`
- make links and script buttons white until hovered

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d6ea943fc8321a736fb728e5b1958