### PR TITLE
Switch to local font

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Thumbs.db
 
 # Optional: Ignore local project scripts/documents if needed
 LeaderPrompt/projects/
+# Ignore font binaries
+public/fonts/*.otf

--- a/index.html
+++ b/index.html
@@ -4,9 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Metropolis:wght@400;700&display=swap" rel="stylesheet" />
     <title>LeaderPrompt</title>
   </head>
   <body>

--- a/public/fonts/README.md
+++ b/public/fonts/README.md
@@ -1,0 +1,1 @@
+Place Metropolis-Bold.otf in this directory to use the bundled font.

--- a/src/App.css
+++ b/src/App.css
@@ -7,7 +7,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Metropolis', sans-serif;
+  font-family: 'Metropolis-Bold', sans-serif;
   background-color: #1e1e1e;
   color: #e0e0e0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,12 @@
+@font-face {
+  font-family: 'Metropolis-Bold';
+  src: url('/fonts/Metropolis-Bold.otf') format('opentype');
+  font-weight: 700;
+  font-style: normal;
+}
+
 :root {
-  font-family: 'Metropolis', sans-serif;
+  font-family: 'Metropolis-Bold', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
## Summary
- remove Metropolis-Bold binary font
- ignore font binaries in git
- add placeholder README for `public/fonts`
- keep `@font-face` rule referencing the local font

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d7711a7f08321892d0825358fcb15