### PR TITLE
Remove hover underlines & accent prompter controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -203,7 +203,6 @@ body {
 
 .script-button:hover {
   color: var(--accent-color);
-  text-decoration: underline;
 }
 
 

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -19,3 +19,8 @@
   color: #e0e0e0;
   font-size: 14px;
 }
+
+.prompter-controls input[type="range"],
+.prompter-controls input[type="checkbox"] {
+  accent-color: var(--accent-color);
+}

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -63,7 +63,7 @@
 }
 
 .close-button:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 .lets-go-button {


### PR DESCRIPTION
## Summary
- remove text underline from script items & close button on hover
- color teleprompter controls with the app accent

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d848142608321b867f36286083ecf