### PR TITLE
Add teleprompter customization options

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -3,9 +3,9 @@
   overflow-y: scroll;
   background: #000000;
   color: #e0e0e0;
-  font-size: 2rem;
   line-height: 1.6;
   font-family: sans-serif;
+  transform-origin: center;
 }
 
 .prompter-controls {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -1,11 +1,19 @@
 import { useEffect, useState, useRef } from 'react'
 import './Prompter.css'
 
+const MARGIN_MIN = 0
+const MARGIN_MAX = 600
+const SPEED_MIN = 0.25
+const SPEED_MAX = 10
+
 function Prompter() {
   const [content, setContent] = useState('')
   const [autoscroll, setAutoscroll] = useState(false)
   const [speed, setSpeed] = useState(1)
   const [margin, setMargin] = useState(100)
+  const [fontSize, setFontSize] = useState(2)
+  const [mirrorX, setMirrorX] = useState(false)
+  const [mirrorY, setMirrorY] = useState(false)
   const containerRef = useRef(null)
 
   useEffect(() => {
@@ -41,24 +49,52 @@ function Prompter() {
   return (
     <div className="prompter-controls">
       <label>
-        Margin:
+        Margin ({Math.round(((margin - MARGIN_MIN) / (MARGIN_MAX - MARGIN_MIN)) * 100)}%):
         <input
           type="range"
-          min="50"
-          max="400"
+          min={MARGIN_MIN}
+          max={MARGIN_MAX}
           value={margin}
-          onChange={(e) => setMargin(parseInt(e.target.value))}
+          onChange={(e) => setMargin(parseInt(e.target.value, 10))}
         />
       </label>
       <label>
-        Speed:
+        Speed ({Math.round(((speed - SPEED_MIN) / (SPEED_MAX - SPEED_MIN)) * 100)}%):
+        <input
+          type="range"
+          min={SPEED_MIN}
+          max={SPEED_MAX}
+          value={speed}
+          step="0.05"
+          onChange={(e) => setSpeed(parseFloat(e.target.value))}
+        />
+      </label>
+      <label>
+        Font Size ({fontSize}rem):
         <input
           type="range"
           min="1"
-          max="10"
-          value={speed}
-          onChange={(e) => setSpeed(parseInt(e.target.value))}
+          max="6"
+          step="0.1"
+          value={fontSize}
+          onChange={(e) => setFontSize(parseFloat(e.target.value))}
         />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={mirrorX}
+          onChange={() => setMirrorX(!mirrorX)}
+        />
+        Mirror Horizontal
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={mirrorY}
+          onChange={() => setMirrorY(!mirrorY)}
+        />
+        Mirror Vertical
       </label>
       <label>
         <input
@@ -72,7 +108,11 @@ function Prompter() {
       <div
         ref={containerRef}
         className="prompter-container"
-        style={{ padding: `2rem ${margin}px` }}
+        style={{
+          padding: `2rem ${margin}px`,
+          fontSize: `${fontSize}rem`,
+          transform: `scale(${mirrorX ? -1 : 1}, ${mirrorY ? -1 : 1})`,
+        }}
         dangerouslySetInnerHTML={{ __html: content }}
       />
     </div>


### PR DESCRIPTION
## Summary
- allow mirroring horizontally or vertically
- add font size slider
- display margin and speed sliders as percentages
- widen the margin slider range and slowest speed
- adjust styles to support new settings

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d85372ad883219e29fe149a8384fb