### PR TITLE
Add transparent teleprompter mode

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -92,7 +92,8 @@ function createPrompterWindow(initialHtml) {
       contextIsolation: true,
       sandbox: true,
     },
-    backgroundColor: '#000000',
+    backgroundColor: '#00000000',
+    transparent: true,
   });
 
   const url = app.isPackaged
@@ -151,6 +152,12 @@ app.whenReady().then(() => {
     targets.forEach((win) => {
       win.webContents.send('update-script', html);
     });
+  });
+
+  ipcMain.on('set-prompter-always-on-top', (_, flag) => {
+    if (prompterWindow && !prompterWindow.isDestroyed()) {
+      prompterWindow.setAlwaysOnTop(!!flag);
+    }
   });
 
   ipcMain.handle('get-all-projects-with-scripts', async () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -32,4 +32,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('load-script', projectName, scriptName),
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
+
+  setPrompterAlwaysOnTop: (flag) =>
+    ipcRenderer.send('set-prompter-always-on-top', flag),
 });

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -1,3 +1,7 @@
+.prompter-wrapper {
+  height: 100vh;
+}
+
 .prompter-container {
   height: 100vh;
   overflow-y: scroll;
@@ -18,6 +22,13 @@
   border-radius: 8px;
   color: #e0e0e0;
   font-size: 14px;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.prompter-wrapper:hover .prompter-controls,
+.prompter-controls:focus-within {
+  opacity: 1;
 }
 
 .prompter-controls input[type="range"],

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -14,6 +14,9 @@ function Prompter() {
   const [fontSize, setFontSize] = useState(2)
   const [mirrorX, setMirrorX] = useState(false)
   const [mirrorY, setMirrorY] = useState(false)
+  const [transparent, setTransparent] = useState(false)
+  const [showShadow, setShowShadow] = useState(true)
+  const [showStroke, setShowStroke] = useState(false)
   const containerRef = useRef(null)
 
   useEffect(() => {
@@ -46,8 +49,15 @@ function Prompter() {
     return () => cancelAnimationFrame(requestId)
   }, [autoscroll, speed])
 
+  useEffect(() => {
+    window.electronAPI.setPrompterAlwaysOnTop(transparent)
+    const root = document.documentElement
+    root.style.background = transparent ? 'transparent' : ''
+  }, [transparent])
+
   return (
-    <div className="prompter-controls">
+    <div className="prompter-wrapper">
+      <div className="prompter-controls">
       <label>
         Margin ({Math.round(((margin - MARGIN_MIN) / (MARGIN_MAX - MARGIN_MIN)) * 100)}%):
         <input
@@ -104,6 +114,30 @@ function Prompter() {
         />
         Auto-scroll
       </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={transparent}
+          onChange={() => setTransparent(!transparent)}
+        />
+        Transparent Mode
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={showShadow}
+          onChange={() => setShowShadow(!showShadow)}
+        />
+        Text Shadow
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={showStroke}
+          onChange={() => setShowStroke(!showStroke)}
+        />
+        Text Stroke
+      </label>
 
       <div
         ref={containerRef}
@@ -112,9 +146,16 @@ function Prompter() {
           padding: `2rem ${margin}px`,
           fontSize: `${fontSize}rem`,
           transform: `scale(${mirrorX ? -1 : 1}, ${mirrorY ? -1 : 1})`,
+          background: transparent ? 'transparent' : '#000',
+          color: '#e0e0e0',
+          textShadow: showShadow
+            ? '0 0 8px rgba(0,0,0,0.8)'
+            : 'none',
+          WebkitTextStroke: showStroke ? '1px black' : '0',
         }}
         dangerouslySetInnerHTML={{ __html: content }}
       />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- expose `setPrompterAlwaysOnTop` in preload
- handle `set-prompter-always-on-top` in electron main process
- create prompter windows with `transparent` background support
- fade prompter control panel on hover
- add transparent mode, text shadow and stroke options
- fix control fade to target only panel and adjust root background when transparent

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e818445f88321943e548b5ef6ecd2