### PR TITLE
Add full viewport width for prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -1,5 +1,6 @@
 .prompter-wrapper {
   height: 100vh;
+  width: 100vw;
 }
 
 .prompter-container {


### PR DESCRIPTION
## Summary
- update prompter wrapper CSS so it spans the full viewport

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e9d35eeb883219ae6cea080b8a8fe