### PR TITLE
Fix transparent mode background color

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -52,7 +52,8 @@ function Prompter() {
   useEffect(() => {
     window.electronAPI.setPrompterAlwaysOnTop(transparent)
     const root = document.documentElement
-    root.style.background = transparent ? 'transparent' : ''
+    root.style.background = transparent ? 'transparent' : '#1e1e1e'
+    root.style.backgroundColor = transparent ? 'transparent' : '#1e1e1e'
   }, [transparent])
 
   return (


### PR DESCRIPTION
## Summary
- update transparency effect in `Prompter` to set both `background` and `backgroundColor`
- ensure the background resets to `#1e1e1e` when transparent mode is disabled

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686e9d35c9f883218ca01238984f4076