### PR TITLE
Fix Prompter layout

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -138,7 +138,7 @@ function Prompter() {
         />
         Text Stroke
       </label>
-
+      </div>
       <div
         ref={containerRef}
         className="prompter-container"
@@ -155,7 +155,6 @@ function Prompter() {
         }}
         dangerouslySetInnerHTML={{ __html: content }}
       />
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- close prompter-controls div before rendering prompter-container
- keep wrapper div as only remaining parent of both sections

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e9d344fc08321a91887b7ca11ae63