### PR TITLE
Fix transparency background handling

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -51,9 +51,9 @@ function Prompter() {
 
   useEffect(() => {
     window.electronAPI.setPrompterAlwaysOnTop(transparent)
-    const root = document.documentElement
-    root.style.background = transparent ? 'transparent' : '#1e1e1e'
-    root.style.backgroundColor = transparent ? 'transparent' : '#1e1e1e'
+    const color = transparent ? 'transparent' : '#1e1e1e'
+    document.documentElement.style.backgroundColor = color
+    document.body.style.backgroundColor = color
   }, [transparent])
 
   return (


### PR DESCRIPTION
## Summary
- adjust transparency effect to set background color on both document root and body

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ea32840348321bcb19dfa877bde65