### PR TITLE
Fix prompter transparency

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -94,8 +94,8 @@ function createPrompterWindow(initialHtml) {
       sandbox: true,
     },
     icon: path.resolve(__dirname, '..', 'public', 'logos', 'LP_white.png'),
-    backgroundColor: '#000000',
-
+    backgroundColor: '#00000000',
+    frame: true,
     transparent: true,
   });
 


### PR DESCRIPTION
## Summary
- make the prompter window fully transparent
- keep the native frame on Windows

## Testing
- `npm run lint`
- `npm run build`
- `npx electron --no-sandbox electron/main.cjs` *(fails: Missing X server)*

------
https://chatgpt.com/codex/tasks/task_e_686ea32908f48321b71989d3eba7f375