### PR TITLE
Add frameless transparent prompter option

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -84,7 +84,7 @@ function createMainWindow() {
   log('Main window created and loaded');
 }
 
-function createPrompterWindow(initialHtml) {
+function createPrompterWindow(initialHtml, transparentMode = false) {
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
@@ -95,7 +95,7 @@ function createPrompterWindow(initialHtml) {
     },
     icon: path.resolve(__dirname, '..', 'public', 'logos', 'LP_white.png'),
     backgroundColor: '#00000000',
-    frame: true,
+    frame: !transparentMode,
     transparent: true,
     titleBarStyle: 'default',
   });
@@ -133,10 +133,10 @@ app.whenReady().then(() => {
   });
 
   // --- IPC Handlers ---
-  ipcMain.on('open-prompter', (_, html) => {
+  ipcMain.on('open-prompter', (_, html, transparentFlag) => {
     log('Received request to open prompter');
-    if (!prompterWindow || prompterWindow.isDestroyed()) {
-      createPrompterWindow(html);
+    if (!prompterWindow || prompterWindow.isDestroyed() || transparentFlag) {
+      createPrompterWindow(html, !!transparentFlag);
     } else {
       prompterWindow.focus();
       prompterWindow.webContents.send('load-script', html);

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -4,7 +4,8 @@ console.log('[PRELOAD] Preload script loaded ✅');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Prompter controls
-  openPrompter: (html) => ipcRenderer.send('open-prompter', html),
+  openPrompter: (html, transparent = false) =>
+    ipcRenderer.send('open-prompter', html, transparent),
   onScriptLoaded: (callback) =>
     ipcRenderer.on('load-script', (_, data) => callback(data)),
   onScriptUpdated: (callback) =>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,7 +53,7 @@ function App() {
 
   const handleSendToPrompter = () => {
     if (scriptHtml) {
-      window.electronAPI.openPrompter(scriptHtml);
+      window.electronAPI.openPrompter(scriptHtml, false);
       setLoadedProject(selectedProject);
       setLoadedScript(selectedScript);
     }

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -36,3 +36,12 @@
 .prompter-controls input[type="checkbox"] {
   accent-color: var(--accent-color);
 }
+
+.drag-header {
+  width: 100%;
+  height: 30px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  -webkit-app-region: drag;
+}

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -54,10 +54,15 @@ function Prompter() {
     const color = transparent ? 'transparent' : '#1e1e1e'
     document.documentElement.style.backgroundColor = color
     document.body.style.backgroundColor = color
-  }, [transparent])
+    if (transparent) {
+      window.electronAPI.openPrompter(content, true)
+    }
+    // intentionally omit "content" from deps
+  }, [transparent]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div className="prompter-wrapper">
+      <div className="drag-header" />
       <div className="prompter-controls">
       <label>
         Margin ({Math.round(((margin - MARGIN_MIN) / (MARGIN_MAX - MARGIN_MIN)) * 100)}%):


### PR DESCRIPTION
## Summary
- allow `createPrompterWindow` to build frameless transparent windows
- expose transparent flag through preload and renderer
- spawn a new transparent window when "Transparent Mode" is enabled
- add draggable header so frameless windows can move

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ead976a708321be14feeb12ad61a9