### PR TITLE
Add custom drag/resize handles

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -95,7 +95,7 @@ function createPrompterWindow(initialHtml, transparentMode = false) {
     },
     icon: path.resolve(__dirname, '..', 'public', 'logos', 'LP_white.png'),
     backgroundColor: '#00000000',
-    frame: !transparentMode,
+    frame: false,
     transparent: true,
     titleBarStyle: 'default',
   });
@@ -161,6 +161,19 @@ app.whenReady().then(() => {
   ipcMain.on('set-prompter-always-on-top', (_, flag) => {
     if (prompterWindow && !prompterWindow.isDestroyed()) {
       prompterWindow.setAlwaysOnTop(!!flag);
+    }
+  });
+
+  ipcMain.handle('get-prompter-bounds', () => {
+    if (prompterWindow && !prompterWindow.isDestroyed()) {
+      return prompterWindow.getBounds();
+    }
+    return null;
+  });
+
+  ipcMain.on('set-prompter-bounds', (_, bounds) => {
+    if (prompterWindow && !prompterWindow.isDestroyed() && bounds) {
+      prompterWindow.setBounds(bounds);
     }
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -36,4 +36,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   setPrompterAlwaysOnTop: (flag) =>
     ipcRenderer.send('set-prompter-always-on-top', flag),
+
+  getPrompterBounds: () => ipcRenderer.invoke('get-prompter-bounds'),
+  setPrompterBounds: (bounds) =>
+    ipcRenderer.send('set-prompter-bounds', bounds),
 });

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -45,3 +45,74 @@
   left: 0;
   -webkit-app-region: drag;
 }
+
+.resize-handle {
+  position: fixed;
+  z-index: 998;
+  -webkit-app-region: no-drag;
+  background: rgba(255, 255, 255, 0.01);
+}
+
+.resize-handle.top,
+.resize-handle.bottom {
+  left: 0;
+  right: 0;
+  height: 6px;
+  cursor: ns-resize;
+}
+
+.resize-handle.top {
+  top: 0;
+}
+
+.resize-handle.bottom {
+  bottom: 0;
+}
+
+.resize-handle.left,
+.resize-handle.right {
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  cursor: ew-resize;
+}
+
+.resize-handle.left {
+  left: 0;
+}
+
+.resize-handle.right {
+  right: 0;
+}
+
+.resize-handle.top-left,
+.resize-handle.top-right,
+.resize-handle.bottom-left,
+.resize-handle.bottom-right {
+  width: 10px;
+  height: 10px;
+}
+
+.resize-handle.top-left {
+  top: 0;
+  left: 0;
+  cursor: nwse-resize;
+}
+
+.resize-handle.top-right {
+  top: 0;
+  right: 0;
+  cursor: nesw-resize;
+}
+
+.resize-handle.bottom-left {
+  bottom: 0;
+  left: 0;
+  cursor: nesw-resize;
+}
+
+.resize-handle.bottom-right {
+  bottom: 0;
+  right: 0;
+  cursor: nwse-resize;
+}

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -19,6 +19,40 @@ function Prompter() {
   const [strokeWidth, setStrokeWidth] = useState(0)
   const containerRef = useRef(null)
 
+  const startResize = async (e, edge) => {
+    e.preventDefault()
+    const startX = e.screenX
+    const startY = e.screenY
+    const bounds = await window.electronAPI.getPrompterBounds()
+
+    const onMove = (ev) => {
+      const dx = ev.screenX - startX
+      const dy = ev.screenY - startY
+      const newBounds = { ...bounds }
+
+      if (edge.includes('right')) newBounds.width = Math.max(100, bounds.width + dx)
+      if (edge.includes('bottom')) newBounds.height = Math.max(100, bounds.height + dy)
+      if (edge.includes('left')) {
+        newBounds.width = Math.max(100, bounds.width - dx)
+        newBounds.x = bounds.x + dx
+      }
+      if (edge.includes('top')) {
+        newBounds.height = Math.max(100, bounds.height - dy)
+        newBounds.y = bounds.y + dy
+      }
+
+      window.electronAPI.setPrompterBounds(newBounds)
+    }
+
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
+
   useEffect(() => {
     const handleLoaded = (html) => {
       setContent(html)
@@ -63,6 +97,14 @@ function Prompter() {
   return (
     <div className="prompter-wrapper">
       <div className="drag-header" />
+      <div className="resize-handle top" onMouseDown={(e) => startResize(e, 'top')} />
+      <div className="resize-handle bottom" onMouseDown={(e) => startResize(e, 'bottom')} />
+      <div className="resize-handle left" onMouseDown={(e) => startResize(e, 'left')} />
+      <div className="resize-handle right" onMouseDown={(e) => startResize(e, 'right')} />
+      <div className="resize-handle top-left" onMouseDown={(e) => startResize(e, 'top-left')} />
+      <div className="resize-handle top-right" onMouseDown={(e) => startResize(e, 'top-right')} />
+      <div className="resize-handle bottom-left" onMouseDown={(e) => startResize(e, 'bottom-left')} />
+      <div className="resize-handle bottom-right" onMouseDown={(e) => startResize(e, 'bottom-right')} />
       <div className="prompter-controls">
       <label>
         Margin ({Math.round(((margin - MARGIN_MIN) / (MARGIN_MAX - MARGIN_MIN)) * 100)}%):


### PR DESCRIPTION
## Summary
- remove system frame from prompter window
- expose IPC APIs to get/set prompter bounds
- implement custom drag and resize overlay in Prompter
- style subtle resize handles

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686eafce76288321a139ef6574e563b7