### PR TITLE
Fix transparency duplication and add drag bezel

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -135,8 +135,17 @@ app.whenReady().then(() => {
   // --- IPC Handlers ---
   ipcMain.on('open-prompter', (_, html, transparentFlag) => {
     log('Received request to open prompter');
-    if (!prompterWindow || prompterWindow.isDestroyed() || transparentFlag) {
-      createPrompterWindow(html, !!transparentFlag);
+
+    if (transparentFlag) {
+      if (prompterWindow && !prompterWindow.isDestroyed()) {
+        prompterWindow.close();
+      }
+      createPrompterWindow(html, true);
+      return;
+    }
+
+    if (!prompterWindow || prompterWindow.isDestroyed()) {
+      createPrompterWindow(html, false);
     } else {
       prompterWindow.focus();
       prompterWindow.webContents.send('load-script', html);

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -39,11 +39,20 @@
 
 .drag-header {
   width: 100%;
-  height: 30px;
+  height: 6px;
   position: fixed;
   top: 0;
   left: 0;
+  background: rgba(0, 0, 0, 0.6);
   -webkit-app-region: drag;
+  z-index: 999;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.prompter-wrapper:hover .drag-header,
+.drag-header:hover {
+  opacity: 1;
 }
 
 .resize-handle {


### PR DESCRIPTION
## Summary
- close old prompter window before launching transparent mode
- add a thin top bezel that appears with prompter controls for easier dragging

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686eb3a760bc8321af4185333ab0dc92