### PR TITLE
Fix transparency duplication and revert bezel

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -135,8 +135,20 @@ app.whenReady().then(() => {
   // --- IPC Handlers ---
   ipcMain.on('open-prompter', (_, html, transparentFlag) => {
     log('Received request to open prompter');
-    if (!prompterWindow || prompterWindow.isDestroyed() || transparentFlag) {
-      createPrompterWindow(html, !!transparentFlag);
+
+    if (transparentFlag) {
+      const reopen = () => createPrompterWindow(html, true);
+      if (prompterWindow && !prompterWindow.isDestroyed()) {
+        prompterWindow.once('closed', reopen);
+        prompterWindow.close();
+      } else {
+        reopen();
+      }
+      return;
+    }
+
+    if (!prompterWindow || prompterWindow.isDestroyed()) {
+      createPrompterWindow(html, false);
     } else {
       prompterWindow.focus();
       prompterWindow.webContents.send('load-script', html);


### PR DESCRIPTION
## Summary
- reopen transparent prompter after the old window finishes closing
- restore drag header to previous style so window can be moved

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eb3a760bc8321af4185333ab0dc92