### PR TITLE
Improve transparency toggle

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -90,9 +90,7 @@ function Prompter() {
     const color = transparent ? 'transparent' : '#1e1e1e'
     document.documentElement.style.backgroundColor = color
     document.body.style.backgroundColor = color
-    if (transparent) {
-      window.electronAPI.openPrompter(content, true)
-    }
+    window.electronAPI.openPrompter(content, transparent)
     // intentionally omit "content" from deps
   }, [transparent]) // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Summary
- conditionally apply transparency options in BrowserWindow
- reopen prompter window only when transparency mode changes
- update Prompter to request transparency changes without always reopening

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686eb8eecbb48321980513d944db4062