### PR TITLE
Skip first openPrompter call

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -20,6 +20,7 @@ function Prompter() {
   const [lineHeight, setLineHeight] = useState(1.6)
   const [textAlign, setTextAlign] = useState('left')
   const containerRef = useRef(null)
+  const initialized = useRef(false)
 
   const startResize = async (e, edge) => {
     e.preventDefault()
@@ -86,6 +87,10 @@ function Prompter() {
   }, [autoscroll, speed])
 
   useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true
+      return
+    }
     window.electronAPI.setPrompterAlwaysOnTop(transparent)
     const color = transparent ? 'transparent' : '#1e1e1e'
     document.documentElement.style.backgroundColor = color


### PR DESCRIPTION
## Summary
- add an `initialized` ref in Prompter
- skip calling `openPrompter` on the initial render of transparency effect

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ebc66298c8321b0d69a33edb9d88e