### PR TITLE
Sync transparency changes with main process

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -121,6 +121,7 @@ function createPrompterWindow(initialHtml, transparentMode = false) {
   win.loadURL(url);
   win.webContents.on('did-finish-load', () => {
     if (initialHtml) win.webContents.send('load-script', initialHtml);
+    win.webContents.send('set-transparent', transparentMode);
   });
 
   prompterWindow = win;

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -11,6 +11,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onScriptUpdated: (callback) =>
     ipcRenderer.on('update-script', (_, data) => callback(data)),
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
+  onTransparentChange: (callback) =>
+    ipcRenderer.on('set-transparent', (_, flag) => callback(flag)),
 
   // Project management
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -20,6 +20,7 @@ function Prompter() {
   const [lineHeight, setLineHeight] = useState(1.6)
   const [textAlign, setTextAlign] = useState('left')
   const containerRef = useRef(null)
+  const initialized = useRef(false)
 
   const startResize = async (e, edge) => {
     e.preventDefault()
@@ -73,6 +74,16 @@ function Prompter() {
   }, [])
 
   useEffect(() => {
+    const handleTransparent = (flag) => {
+      setTransparent(flag)
+    }
+    window.electronAPI.onTransparentChange(handleTransparent)
+    return () => {
+      window.ipcRenderer?.removeListener('set-transparent', handleTransparent)
+    }
+  }, [])
+
+  useEffect(() => {
     if (!autoscroll) return undefined
     let requestId
     const step = () => {
@@ -86,6 +97,10 @@ function Prompter() {
   }, [autoscroll, speed])
 
   useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true
+      return
+    }
     window.electronAPI.setPrompterAlwaysOnTop(transparent)
     const color = transparent ? 'transparent' : '#1e1e1e'
     document.documentElement.style.backgroundColor = color


### PR DESCRIPTION
## Summary
- notify renderer of the current transparency setting when a prompter window loads
- expose `onTransparentChange` in the preload API
- listen for transparency updates in `Prompter.jsx`
- guard first-run transparency effect to avoid reopening the prompter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ebc67b3f48321ba4fdd836a65fac7