### PR TITLE
Implement prompter-ready IPC handshake

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onScriptUpdated: (callback) =>
     ipcRenderer.on('update-script', (_, data) => callback(data)),
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
+  prompterReady: () => ipcRenderer.send('prompter-ready'),
   onTransparentChange: (callback) =>
     ipcRenderer.on('set-transparent', (_, flag) => callback(flag)),
 

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -66,6 +66,7 @@ function Prompter() {
 
     window.electronAPI.onScriptLoaded(handleLoaded)
     window.electronAPI.onScriptUpdated(handleUpdated)
+    window.electronAPI.prompterReady()
 
     return () => {
       window.ipcRenderer?.removeListener('load-script', handleLoaded)


### PR DESCRIPTION
## Summary
- keep track of last loaded script in main process
- add `prompter-ready` IPC channel so the prompter window can request the last script and transparency state
- expose `prompterReady` from preload
- request the info when `Prompter` component mounts
- retain `did-finish-load` script send as fallback

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686ec07fa2588321becc5e1000d2c097