### PR TITLE
Make prompter window frameless and update UI

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -39,6 +39,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setPrompterAlwaysOnTop: (flag) =>
     ipcRenderer.send('set-prompter-always-on-top', flag),
 
+  closePrompter: () => ipcRenderer.send('close-prompter'),
+  minimizePrompter: () => ipcRenderer.send('minimize-prompter'),
+
   getPrompterBounds: () => ipcRenderer.invoke('get-prompter-bounds'),
   setPrompterBounds: (bounds) =>
     ipcRenderer.send('set-prompter-bounds', bounds),

--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -53,11 +53,9 @@
 
 .drag-header {
   width: 100%;
-  height: 6px;
   position: fixed;
   top: 0;
   left: 0;
-  background: rgba(0, 0, 0, 0.6);
   -webkit-app-region: drag;
   z-index: 999;
   opacity: 0;
@@ -67,6 +65,26 @@
 .prompter-wrapper:hover .drag-header,
 .drag-header:hover {
   opacity: 1;
+}
+
+.window-buttons {
+  position: absolute;
+  top: 0;
+  right: 4px;
+  display: flex;
+  gap: 4px;
+  -webkit-app-region: no-drag;
+}
+
+.window-buttons button {
+  width: 18px;
+  height: 18px;
+  font-size: 12px;
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  padding: 0;
 }
 
 .resize-handle {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -109,9 +109,26 @@ function Prompter() {
     // intentionally omit "content" from deps
   }, [transparent]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const headerStyle = {
+    height: transparent ? '6px' : '28px',
+    background: transparent ? 'rgba(0,0,0,0.1)' : '#333',
+    boxShadow: transparent ? 'none' : '0 2px 4px rgba(0,0,0,0.5)',
+  }
+
   return (
     <div className="prompter-wrapper">
-      <div className="drag-header" />
+      <div className="drag-header" style={headerStyle}>
+        {!transparent && (
+          <div className="window-buttons">
+            <button onClick={() => window.electronAPI.minimizePrompter()}>
+              &minus;
+            </button>
+            <button onClick={() => window.electronAPI.closePrompter()}>
+              &times;
+            </button>
+          </div>
+        )}
+      </div>
       <div className="resize-handle top" onMouseDown={(e) => startResize(e, 'top')} />
       <div className="resize-handle bottom" onMouseDown={(e) => startResize(e, 'bottom')} />
       <div className="resize-handle left" onMouseDown={(e) => startResize(e, 'left')} />


### PR DESCRIPTION
## Summary
- always create prompter window with `frame:false` and `transparent:true`
- simplify `open-prompter` logic to avoid closing/reopening
- expose APIs to close or minimize the prompter
- add custom title bar with buttons and styles for transparent vs. solid modes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ec07dc5c08321bb29d859da7a3534