### PR TITLE
Fix prompter initialization and transparency

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -13,6 +13,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
   onTransparentChange: (callback) =>
     ipcRenderer.on('set-transparent', (_, flag) => callback(flag)),
+  getCurrentScript: () => ipcRenderer.invoke('get-current-script'),
 
   // Project management
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -66,6 +66,9 @@ function Prompter() {
 
     window.electronAPI.onScriptLoaded(handleLoaded)
     window.electronAPI.onScriptUpdated(handleUpdated)
+    window.electronAPI.getCurrentScript().then((html) => {
+      if (html) setContent(html)
+    })
 
     return () => {
       window.ipcRenderer?.removeListener('load-script', handleLoaded)


### PR DESCRIPTION
## Summary
- retain last script HTML in main process
- recreate prompter window when transparency mode changes
- expose `get-current-script` from main and preload
- fetch current script on prompter mount to ensure text loads

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ec47edbc4832197a36b20aa9179f0