### PR TITLE
Initialize separate prompter windows

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -37,6 +37,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
 
+  onLogMessage: (callback) =>
+    ipcRenderer.on('log-message', (_, msg) => callback(msg)),
+
   setPrompterAlwaysOnTop: (flag) =>
     ipcRenderer.send('set-prompter-always-on-top', flag),
 

--- a/src/DevConsole.css
+++ b/src/DevConsole.css
@@ -1,0 +1,12 @@
+.dev-console {
+  background: #000;
+  color: #0f0;
+  font-family: monospace;
+  padding: 8px;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.log-line {
+  white-space: pre-wrap;
+}

--- a/src/DevConsole.jsx
+++ b/src/DevConsole.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import './DevConsole.css'
+
+function DevConsole() {
+  const [logs, setLogs] = useState([])
+
+  useEffect(() => {
+    const handler = (_, msg) => {
+      setLogs((prev) => [...prev, msg])
+    }
+    window.electronAPI.onLogMessage(handler)
+    return () => {
+      window.ipcRenderer?.removeListener('log-message', handler)
+    }
+  }, [])
+
+  return (
+    <div className="dev-console">
+      {logs.map((msg, idx) => (
+        <div key={idx} className="log-line">{msg}</div>
+      ))}
+    </div>
+  )
+}
+
+export default DevConsole

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import './index.css'
 
 import App from './App.jsx'
 import Prompter from './Prompter.jsx'
+import DevConsole from './DevConsole.jsx'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
@@ -12,6 +13,7 @@ createRoot(document.getElementById('root')).render(
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/prompter" element={<Prompter />} />
+        <Route path="/dev-console" element={<DevConsole />} />
       </Routes>
     </HashRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- create an opaque and a transparent prompter window when needed
- keep both windows hidden until used
- switch visibility in `open-prompter` instead of recreating windows
- delay prompter window initialization until user actually opens the prompter
- add dedicated dev console window and verbose logging

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ec8d06e108321aff5770e4a62bd30