### PR TITLE
Fix prompter close handler

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -294,10 +294,16 @@ app.whenReady().then(() => {
   });
 
   ipcMain.on('close-prompter', () => {
-    if (prompterWindow && !prompterWindow.isDestroyed()) {
-      prompterWindow.close();
-    }
-    log('Prompter window closed');
+    [prompterWindowOpaque, prompterWindowTransparent].forEach((win) => {
+      if (win && !win.isDestroyed()) {
+        win.close();
+      }
+      prompterWindows.delete(win);
+    });
+    prompterWindow = null;
+    prompterWindowOpaque = null;
+    prompterWindowTransparent = null;
+    log('Prompter windows closed');
   });
 
   ipcMain.on('minimize-prompter', () => {


### PR DESCRIPTION
## Summary
- close both opaque and transparent prompter windows
- clear all window references on close and clean the prompter windows set

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ed56b6ee48321be6dc6e07bb9841a