### PR TITLE
Enable new script creation

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -23,6 +23,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteProject: (name) => ipcRenderer.invoke('delete-project', name),
   renameScript: (projectName, oldName, newName) =>
     ipcRenderer.invoke('rename-script', projectName, oldName, newName),
+  createNewScript: (projectName, scriptName) =>
+    ipcRenderer.invoke('create-new-script', projectName, scriptName),
 
   // Script import/load controls
   importScriptsToProject: (filePaths, projectName) =>

--- a/src/App.css
+++ b/src/App.css
@@ -80,6 +80,11 @@ body {
   font-size: 18px;
 }
 
+.header-buttons {
+  display: flex;
+  gap: var(--space-2);
+}
+
 .file-manager-header button {
   padding: var(--space-2) var(--space-4);
   background-color: #333;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,7 +91,7 @@ function App() {
       <div className="right-panel">
         <ScriptViewer
           scriptHtml={scriptHtml}
-          showLogo={!scriptHtml}
+          showLogo={scriptHtml === null}
           onSend={handleSendToPrompter}
           onEdit={handleScriptEdit}
           onClose={handleCloseScript}

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -89,6 +89,20 @@ function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
     await loadProjects();
   };
 
+  const handleNewScript = async () => {
+    const projectName = await window.electronAPI.selectProjectFolder();
+    if (!projectName) return;
+    const scriptName = prompt('New script name:');
+    if (!scriptName) return;
+    const result = await window.electronAPI.createNewScript(projectName, scriptName);
+    if (result && result.success) {
+      await loadProjects();
+      onScriptSelect(projectName, result.scriptName);
+    } else {
+      alert('Failed to create script');
+    }
+  };
+
   const startRenameProject = (name) => {
     setRenamingScript(null);
     setRenamingProject(name);
@@ -150,7 +164,12 @@ function FileManager({ onScriptSelect, loadedProject, loadedScript }) {
     <div className="file-manager">
       <div className="file-manager-header">
         <h3>Projects</h3>
-        <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>+ New Project</button>
+        <div className="header-buttons">
+          <button onClick={handleNewScript}>+ New Script</button>
+          <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>
+            + New Project
+          </button>
+        </div>
       </div>
 
       {showNewProjectInput && (


### PR DESCRIPTION
## Summary
- add `create-new-script` handler on the backend
- expose `createNewScript` on the preload bridge
- support creating scripts from the FileManager
- show placeholder only when no script is loaded
- style header buttons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870143393348321a2c218ddc1047605