### PR TITLE
Fix electron main window production loading

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -116,7 +116,11 @@ function createMainWindow() {
     backgroundColor: '#000000',
   });
 
-  mainWindow.loadURL('http://localhost:5173');
+  const startUrl = app.isPackaged
+    ? pathToFile('dist/index.html')
+    : 'http://localhost:5173';
+
+  mainWindow.loadURL(startUrl);
   log('Main window created and loaded');
 }
 


### PR DESCRIPTION
## Summary
- load `dist/index.html` for packaged builds
- keep localhost for dev mode

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68701d1a1e808321ace446e635bd697d