### PR TITLE
Handle project metadata read errors

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -90,8 +90,22 @@ function ensureDirectories() {
 }
 
 function getProjectMetadata() {
-  const raw = fs.readFileSync(getProjectMetadataPath(), 'utf-8');
-  return JSON.parse(raw);
+  try {
+    const raw = fs.readFileSync(getProjectMetadataPath(), 'utf-8');
+    return JSON.parse(raw);
+  } catch (err) {
+    error('Failed to read or parse project metadata:', err);
+    const fallback = { projects: [] };
+    try {
+      fs.writeFileSync(
+        getProjectMetadataPath(),
+        JSON.stringify(fallback, null, 2),
+      );
+    } catch (writeErr) {
+      error('Failed to recreate projects.json:', writeErr);
+    }
+    return fallback;
+  }
 }
 
 function updateProjectMetadata(projectName) {


### PR DESCRIPTION
## Summary
- guard `getProjectMetadata()` against JSON read/parse errors
- recreate `projects.json` with default empty metadata when the file can't be read

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870217b7ee88321af772cc019695d03