### PR TITLE
Retry dev load

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -121,6 +121,22 @@ function createMainWindow() {
     : 'http://localhost:5173';
 
   mainWindow.loadURL(startUrl);
+
+  if (!app.isPackaged) {
+    const retryLoad = () => {
+      setTimeout(() => {
+        if (!mainWindow.isDestroyed()) {
+          mainWindow.loadURL(startUrl);
+        }
+      }, 1000);
+    };
+
+    mainWindow.webContents.on('did-fail-load', retryLoad);
+    mainWindow.webContents.once('did-finish-load', () => {
+      mainWindow.webContents.removeListener('did-fail-load', retryLoad);
+    });
+  }
+
   log('Main window created and loaded');
 }
 


### PR DESCRIPTION
## Summary
- retry `loadURL` when the main window fails to load in development

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68702182bf948321a18ca496069ea200