### PR TITLE
Return log listener cleanup

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -39,8 +39,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
 
-  onLogMessage: (callback) =>
-    ipcRenderer.on('log-message', (_, msg) => callback(msg)),
+  onLogMessage: (callback) => {
+    const handler = (_, msg) => callback(msg)
+    ipcRenderer.on('log-message', handler)
+    return () => ipcRenderer.removeListener('log-message', handler)
+  },
 
   setPrompterAlwaysOnTop: (flag) =>
     ipcRenderer.send('set-prompter-always-on-top', flag),

--- a/src/DevConsole.jsx
+++ b/src/DevConsole.jsx
@@ -8,9 +8,9 @@ function DevConsole() {
     const handler = (msg) => {
       setLogs((prev) => [...prev, msg])
     }
-    window.electronAPI.onLogMessage(handler)
+    const cleanup = window.electronAPI.onLogMessage(handler)
     return () => {
-      window.ipcRenderer?.removeListener('log-message', handler)
+      cleanup?.()
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- return a cleanup function when registering log listener in `preload.cjs`
- use the returned cleanup in `DevConsole.jsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687021840e348321b6703b9a3567048e