### PR TITLE
Wait for Vite server before creating windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ window.electronAPI.onScriptUpdated((html) => {
 ```
 
 This pairs with `sendUpdatedScript(html)` to keep the prompter view in sync.
+
+When running the Electron app in development, the main process now waits for the
+Vite dev server at `http://localhost:5173` to respond before creating any
+windows. This avoids reload loops while Vite is starting.


### PR DESCRIPTION
## Summary
- add a helper to poll `http://localhost:5173` until the server responds
- remove did-fail-load retry logic in `createMainWindow`
- wait for Vite to start before showing windows
- document new behaviour in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687025e28d008321822c960849e16117