### PR TITLE
Fix initial prompter display

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -97,7 +97,9 @@ function Prompter() {
   useEffect(() => {
     if (!initialized.current) {
       initialized.current = true
-      return
+      return () => {
+        initialized.current = false
+      }
     }
     window.electronAPI.setPrompterAlwaysOnTop(transparent)
     const color = transparent ? 'transparent' : '#1e1e1e'


### PR DESCRIPTION
## Summary
- reset initialization state when Prompter unmounts to avoid clearing the active script on first load

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68702ab91e3c8321bd7bae0b517c2476