### PR TITLE
Fix initial prompter display

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -95,14 +95,21 @@ function Prompter() {
   }, [autoscroll, speed])
 
   useEffect(() => {
-    if (!initialized.current) {
-      initialized.current = true
-      return
-    }
+    // keep window visuals in sync on every render
     window.electronAPI.setPrompterAlwaysOnTop(transparent)
     const color = transparent ? 'transparent' : '#1e1e1e'
     document.documentElement.style.backgroundColor = color
     document.body.style.backgroundColor = color
+
+    // avoid re-opening the prompter with empty content during the
+    // StrictMode double-mount
+    if (!initialized.current) {
+      initialized.current = true
+      return () => {
+        initialized.current = false
+      }
+    }
+
     window.electronAPI.openPrompter(content, transparent)
     // intentionally omit "content" from deps
   }, [transparent]) // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- reset initialization state when Prompter unmounts to avoid clearing the active script on first load
- update transparency effect to set colors on first render

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68702ab91e3c8321bd7bae0b517c2476