### PR TITLE
Add prompter-ready handshake

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -309,11 +309,17 @@ app.whenReady().then(async () => {
       prompterWindow = active;
       currentTransparent = desiredTransparent;
       active.setAlwaysOnTop(isAlwaysOnTop);
+
+      ipcMain.once('prompter-ready', () => {
+        if (active && !active.isDestroyed()) {
+          active.show();
+          active.focus();
+          log(`Prompter window shown (transparent: ${desiredTransparent})`);
+        }
+      });
+
       active.webContents.send('load-script', currentScriptHtml);
       active.webContents.send('set-transparent', desiredTransparent);
-      active.show();
-      active.focus();
-      log(`Prompter window shown (transparent: ${desiredTransparent})`);
     }
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -54,4 +54,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getPrompterBounds: () => ipcRenderer.invoke('get-prompter-bounds'),
   setPrompterBounds: (bounds) =>
     ipcRenderer.send('set-prompter-bounds', bounds),
+
+  prompterReady: () => ipcRenderer.send('prompter-ready'),
 });

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -107,6 +107,7 @@ function Prompter() {
     const color = transparent ? 'transparent' : '#1e1e1e'
     document.documentElement.style.backgroundColor = color
     document.body.style.backgroundColor = color
+    window.electronAPI.prompterReady()
 
     // avoid re-opening the prompter with empty content during the
     // StrictMode double-mount


### PR DESCRIPTION
## Summary
- expose `prompterReady` from preload
- notify main process when the prompter renderer has set its background
- wait for `prompter-ready` before showing the prompter window

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687031fc6d088321b5b54769080824ad