### PR TITLE
Debounce saving of script edits

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ function App() {
   const [leftWidth, setLeftWidth] = useState(300);
   const leftRef = useRef(null);
   const isDragging = useRef(false);
+  const saveTimeout = useRef(null);
 
   const onDrag = (e) => {
     if (!isDragging.current) return;
@@ -62,7 +63,13 @@ function App() {
   const handleScriptEdit = (html) => {
     setScriptHtml(html);
     if (selectedProject && selectedScript) {
-      window.electronAPI.saveScript(selectedProject, selectedScript, html);
+      if (saveTimeout.current) {
+        clearTimeout(saveTimeout.current);
+      }
+      saveTimeout.current = setTimeout(() => {
+        window.electronAPI.saveScript(selectedProject, selectedScript, html);
+        saveTimeout.current = null;
+      }, 300);
     }
     if (
       selectedProject === loadedProject &&
@@ -73,6 +80,10 @@ function App() {
   };
 
   const handleCloseScript = () => {
+    if (saveTimeout.current) {
+      clearTimeout(saveTimeout.current);
+      saveTimeout.current = null;
+    }
     if (selectedProject && selectedScript && scriptHtml) {
       window.electronAPI.saveScript(
         selectedProject,


### PR DESCRIPTION
## Summary
- debounce calls to `window.electronAPI.saveScript` during editing
- clear pending save timer when closing a script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687036fe4bdc832187e558df4c5d989c