### PR TITLE
Ensure custom modal used for alerts

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import ActionMenu from './ActionMenu';
 import NameModal from './NameModal';
+import MessageModal from './MessageModal';
 
 function PencilIcon() {
   return (
@@ -55,6 +56,7 @@ function FileManager({
   const [renameValue, setRenameValue] = useState('');
   const [collapsed, setCollapsed] = useState({});
   const [newScriptProject, setNewScriptProject] = useState(null);
+  const [errorMessage, setErrorMessage] = useState(null);
 
   useEffect(() => {
     loadProjects();
@@ -85,7 +87,7 @@ function FileManager({
       setShowNewProjectInput(false);
       loadProjects();
     } else {
-      alert('Failed to create project');
+      setErrorMessage('Failed to create project');
     }
   };
 
@@ -124,8 +126,11 @@ function FileManager({
 
   const confirmRenameProject = async (oldName) => {
     if (!renameValue.trim()) return;
-    const success = await window.electronAPI.renameProject(oldName, renameValue.trim());
-    if (!success) alert('Failed to rename project');
+    const success = await window.electronAPI.renameProject(
+      oldName,
+      renameValue.trim(),
+    );
+    if (!success) setErrorMessage('Failed to rename project');
     cancelRename();
     await loadProjects();
   };
@@ -136,8 +141,12 @@ function FileManager({
     if (!newName.toLowerCase().endsWith('.docx')) {
       newName += '.docx';
     }
-    const success = await window.electronAPI.renameScript(projectName, oldName, newName);
-    if (!success) alert('Failed to rename script');
+    const success = await window.electronAPI.renameScript(
+      projectName,
+      oldName,
+      newName,
+    );
+    if (!success) setErrorMessage('Failed to rename script');
     cancelRename();
     await loadProjects();
   };
@@ -151,7 +160,7 @@ function FileManager({
       await loadProjects();
       onScriptSelect(projectName, result.scriptName);
     } else {
-      alert('Failed to create script');
+      setErrorMessage('Failed to create script');
     }
   };
 
@@ -159,13 +168,13 @@ function FileManager({
 
   const handleDeleteProject = async (projectName) => {
     const deleted = await window.electronAPI.deleteProject(projectName);
-    if (!deleted) alert('Failed to delete project');
+    if (!deleted) setErrorMessage('Failed to delete project');
     await loadProjects();
   };
 
   const handleDeleteScript = async (projectName, scriptName) => {
     const deleted = await window.electronAPI.deleteScript(projectName, scriptName);
-    if (!deleted) alert('Failed to delete script');
+    if (!deleted) setErrorMessage('Failed to delete script');
     await loadProjects();
   };
 
@@ -310,6 +319,13 @@ function FileManager({
           placeholder="Script name"
           onConfirm={confirmNewScript}
           onCancel={cancelNewScript}
+        />
+      )}
+      {errorMessage && (
+        <MessageModal
+          title="Error"
+          message={errorMessage}
+          onClose={() => setErrorMessage(null)}
         />
       )}
     </div>

--- a/src/MessageModal.jsx
+++ b/src/MessageModal.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+function MessageModal({ title = 'Message', message, onClose }) {
+  useEffect(() => {
+    const handle = (e) => {
+      if (e.key === 'Escape' || e.key === 'Enter') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [onClose]);
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-window">
+        {title && <h3>{title}</h3>}
+        <p>{message}</p>
+        <div className="modal-actions">
+          <button onClick={onClose}>OK</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MessageModal;


### PR DESCRIPTION
## Summary
- add `MessageModal` component for generic popup dialogs
- replace `alert()` usage in `FileManager.jsx` with `MessageModal`

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68704260a65c8321ba1368f77ae07aad