### PR TITLE
Handle new script creation with project name prompt

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -20,6 +20,7 @@ let viteProcess;
 let isAlwaysOnTop = false;
 let currentScriptHtml = '';
 let currentTransparent = false;
+const NEW_PROJECT_SENTINEL = '__NEW_PROJECT__';
 
 function mirrorInactiveBoundsFrom(source) {
   if (!source || source.isDestroyed() || prompterWindow !== source) return;
@@ -436,13 +437,8 @@ app.whenReady().then(async () => {
       });
       return choice.response === choices.length ? null : choices[choice.response];
     } else {
-      // Placeholder prompt - improve later
-      log('Creating new project via fallback name');
-      const projectName = 'Untitled Project';
-      const newFolder = path.join(getProjectsPath(), projectName);
-      fs.mkdirSync(newFolder, { recursive: true });
-      updateProjectMetadata(projectName);
-      return projectName;
+      log('Create new project requested');
+      return NEW_PROJECT_SENTINEL;
     }
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -14,6 +14,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   onTransparentChange: (callback) =>
     ipcRenderer.on('set-transparent', (_, flag) => callback(flag)),
   getCurrentScript: () => ipcRenderer.invoke('get-current-script'),
+  NEW_PROJECT_SENTINEL: '__NEW_PROJECT__',
 
   // Project management
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),


### PR DESCRIPTION
## Summary
- return a sentinel from `select-project-folder` when the user chooses to create a project
- expose `NEW_PROJECT_SENTINEL` through preload
- detect the sentinel in `FileManager` and prompt for a project name
- create the project before prompting for the new script name

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870433c5c488321a3130de005ad7077