### PR TITLE
Implement notecard mode in prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -157,3 +157,31 @@
   right: 0;
   cursor: nwse-resize;
 }
+
+.notecard-controls {
+  position: fixed;
+  bottom: var(--space-4);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  background: rgba(0, 0, 0, 0.6);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 6px;
+  z-index: 999;
+}
+
+.notecard-controls button {
+  background: #333;
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+}
+
+.notecard-controls button:hover {
+  background: var(--accent-color);
+}
+
+.notecard-index {
+  align-self: center;
+}


### PR DESCRIPTION
## Summary
- add a notecard layout option in the prompter
- compute slide pages based on font size and container height
- disable autoscroll/speed controls while in notecard mode
- add navigation controls for switching slides

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68705b263be48321969db3410b8d76ac