### PR TITLE
Update prompter controls UI

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -12,44 +12,6 @@
   transform-origin: center;
 }
 
-.prompter-controls {
-  position: fixed;
-  top: var(--space-4);
-  left: var(--space-2);
-  z-index: 999;
-  background: rgba(0, 0, 0, 0.6);
-  padding: var(--space-4);
-  border-radius: 8px;
-  color: #e0e0e0;
-  font-size: 14px;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.prompter-wrapper:hover .prompter-controls,
-.prompter-controls:hover {
-  opacity: 1;
-}
-
-.prompter-controls input[type="range"],
-.prompter-controls input[type="checkbox"] {
-  accent-color: var(--accent-color);
-}
-
-.prompter-controls label {
-  display: block;
-  margin-bottom: var(--space-1);
-}
-
-.prompter-controls details {
-  margin-bottom: var(--space-2);
-}
-
-.prompter-controls summary {
-  cursor: pointer;
-  font-weight: bold;
-  margin-bottom: var(--space-1);
-}
 
 .drag-header {
   width: 100%;
@@ -184,4 +146,54 @@
 
 .notecard-index {
   align-self: center;
+}
+
+.top-controls {
+  position: fixed;
+  top: var(--space-3);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+  background: rgba(0, 0, 0, 0.6);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 6px;
+  z-index: 999;
+  color: #e0e0e0;
+}
+
+.top-controls input[type='range'],
+.top-controls input[type='checkbox'] {
+  accent-color: var(--accent-color);
+}
+
+.settings-button {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+}
+
+.settings-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 260px;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  padding: var(--space-4);
+  overflow-y: auto;
+  z-index: 998;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.settings-panel label {
+  display: block;
+}
+
+.settings-panel input[type='range'],
+.settings-panel input[type='checkbox'] {
+  accent-color: var(--accent-color);
 }

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -22,8 +22,24 @@ function Prompter() {
   const [notecardMode, setNotecardMode] = useState(false)
   const [slides, setSlides] = useState([])
   const [currentSlide, setCurrentSlide] = useState(0)
+  const [settingsOpen, setSettingsOpen] = useState(false)
   const containerRef = useRef(null)
   const initialized = useRef(false)
+
+  const resetDefaults = () => {
+    setAutoscroll(false)
+    setSpeed(1)
+    setMargin(100)
+    setFontSize(2)
+    setMirrorX(false)
+    setMirrorY(false)
+    setTransparent(false)
+    setShadowStrength(8)
+    setStrokeWidth(0)
+    setLineHeight(1.6)
+    setTextAlign('left')
+    setNotecardMode(false)
+  }
 
   const startResize = async (e, edge) => {
     e.preventDefault()
@@ -208,9 +224,57 @@ function Prompter() {
       <div className="resize-handle top-right" onMouseDown={(e) => startResize(e, 'top-right')} />
       <div className="resize-handle bottom-left" onMouseDown={(e) => startResize(e, 'bottom-left')} />
       <div className="resize-handle bottom-right" onMouseDown={(e) => startResize(e, 'bottom-right')} />
-      <div className="prompter-controls">
-        <details open>
-          <summary>Text Styling</summary>
+      <div className="top-controls">
+        <label>
+          <input
+            type="checkbox"
+            checked={autoscroll}
+            onChange={() => setAutoscroll(!autoscroll)}
+            disabled={notecardMode}
+          />
+          Auto-scroll
+        </label>
+        <label>
+          Speed
+          <input
+            type="range"
+            min={SPEED_MIN}
+            max={SPEED_MAX}
+            value={speed}
+            step="0.05"
+            onChange={(e) => setSpeed(parseFloat(e.target.value))}
+            disabled={notecardMode}
+          />
+        </label>
+        <button onClick={() => setMirrorX(!mirrorX)}>MX</button>
+        <button onClick={() => setMirrorY(!mirrorY)}>MY</button>
+        <label>
+          <input
+            type="checkbox"
+            checked={notecardMode}
+            onChange={() => {
+              setNotecardMode(!notecardMode)
+              if (!notecardMode) setAutoscroll(false)
+            }}
+          />
+          Notecard
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={transparent}
+            onChange={() => setTransparent(!transparent)}
+          />
+          Transparent
+        </label>
+        <button className="settings-button" onClick={() => setSettingsOpen(!settingsOpen)}>
+          ⚙
+        </button>
+      </div>
+
+      {settingsOpen && (
+        <div className="settings-panel">
+          <h4>Text Styling</h4>
           <label>
             Font Size ({fontSize}rem):
             <input
@@ -223,22 +287,14 @@ function Prompter() {
             />
           </label>
           <label>
-            Text Alignment:
-            <select value={textAlign} onChange={(e) => setTextAlign(e.target.value)}>
-              <option value="left">Left</option>
-              <option value="center">Center</option>
-              <option value="right">Right</option>
-              <option value="justify">Justify</option>
-            </select>
-          </label>
-          <label>
-            Shadow ({shadowStrength}px)
+            Line Height ({lineHeight})
             <input
               type="range"
-              min="0"
-              max="20"
-              value={shadowStrength}
-              onChange={(e) => setShadowStrength(parseInt(e.target.value, 10))}
+              min="1"
+              max="3"
+              step="0.1"
+              value={lineHeight}
+              onChange={(e) => setLineHeight(parseFloat(e.target.value))}
             />
           </label>
           <label>
@@ -253,19 +309,25 @@ function Prompter() {
             />
           </label>
           <label>
-            Line Height ({lineHeight})
+            Shadow ({shadowStrength}px)
             <input
               type="range"
-              min="1"
-              max="3"
-              step="0.1"
-              value={lineHeight}
-              onChange={(e) => setLineHeight(parseFloat(e.target.value))}
+              min="0"
+              max="20"
+              value={shadowStrength}
+              onChange={(e) => setShadowStrength(parseInt(e.target.value, 10))}
             />
           </label>
-        </details>
-        <details>
-          <summary>Layout &amp; Display</summary>
+          <label>
+            Text Alignment:
+            <select value={textAlign} onChange={(e) => setTextAlign(e.target.value)}>
+              <option value="left">Left</option>
+              <option value="center">Center</option>
+              <option value="right">Right</option>
+              <option value="justify">Justify</option>
+            </select>
+          </label>
+          <h4>Layout &amp; Display</h4>
           <label>
             Margin ({Math.round(((margin - MARGIN_MIN) / (MARGIN_MAX - MARGIN_MIN)) * 100)}%):
             <input
@@ -276,67 +338,9 @@ function Prompter() {
               onChange={(e) => setMargin(parseInt(e.target.value, 10))}
             />
           </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={mirrorX}
-              onChange={() => setMirrorX(!mirrorX)}
-            />
-            Mirror Horizontal
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={mirrorY}
-              onChange={() => setMirrorY(!mirrorY)}
-            />
-            Mirror Vertical
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={transparent}
-              onChange={() => setTransparent(!transparent)}
-            />
-            Transparent Mode
-          </label>
-        </details>
-        <details>
-          <summary>Behavior</summary>
-          <label>
-            <input
-              type="checkbox"
-              checked={notecardMode}
-              onChange={() => {
-                setNotecardMode(!notecardMode)
-                if (!notecardMode) setAutoscroll(false)
-              }}
-            />
-            Notecard Mode
-          </label>
-          <label>
-            Speed ({Math.round(((speed - SPEED_MIN) / (SPEED_MAX - SPEED_MIN)) * 100)}%):
-            <input
-              type="range"
-              min={SPEED_MIN}
-              max={SPEED_MAX}
-              value={speed}
-              step="0.05"
-              onChange={(e) => setSpeed(parseFloat(e.target.value))}
-              disabled={notecardMode}
-            />
-          </label>
-          <label>
-            <input
-              type="checkbox"
-              checked={autoscroll}
-              onChange={() => setAutoscroll(!autoscroll)}
-              disabled={notecardMode}
-            />
-            Auto-scroll
-          </label>
-        </details>
-      </div>
+          <button onClick={resetDefaults}>Reset to defaults</button>
+        </div>
+      )}
       <div
         ref={containerRef}
         className="prompter-container"


### PR DESCRIPTION
## Summary
- restructure prompter settings into a top bar and slide-out panel
- add reset to defaults feature
- simplify styling and drop old hover accordion

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6870665928a48321a7d44d1d869ff4d3