### PR TITLE
Remove drag header from Prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -13,41 +13,6 @@
 }
 
 
-.drag-header {
-  width: 100%;
-  position: fixed;
-  top: 0;
-  left: 0;
-  -webkit-app-region: drag;
-  z-index: 999;
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.prompter-wrapper:hover .drag-header,
-.drag-header:hover {
-  opacity: 1;
-}
-
-.window-buttons {
-  position: absolute;
-  top: 0;
-  right: 4px;
-  display: flex;
-  gap: 4px;
-  -webkit-app-region: no-drag;
-}
-
-.window-buttons button {
-  width: 18px;
-  height: 18px;
-  font-size: 12px;
-  border: none;
-  background: transparent;
-  color: #fff;
-  cursor: pointer;
-  padding: 0;
-}
 
 .resize-handle {
   position: fixed;

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -196,26 +196,8 @@ function Prompter() {
     // intentionally omit "content" from deps
   }, [transparent]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const headerStyle = {
-    height: transparent ? '6px' : '28px',
-    background: transparent ? 'rgba(0,0,0,0.1)' : '#333',
-    boxShadow: transparent ? 'none' : '0 2px 4px rgba(0,0,0,0.5)',
-  }
-
   return (
     <div className="prompter-wrapper">
-      <div className="drag-header" style={headerStyle}>
-        {!transparent && (
-          <div className="window-buttons">
-            <button onClick={() => window.electronAPI.minimizePrompter()}>
-              &minus;
-            </button>
-            <button onClick={() => window.electronAPI.closePrompter()}>
-              &times;
-            </button>
-          </div>
-        )}
-      </div>
       <div className="resize-handle top" onMouseDown={(e) => startResize(e, 'top')} />
       <div className="resize-handle bottom" onMouseDown={(e) => startResize(e, 'bottom')} />
       <div className="resize-handle left" onMouseDown={(e) => startResize(e, 'left')} />


### PR DESCRIPTION
## Summary
- remove the draggable header with minimize and close buttons
- drop related styles

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687066755c488321a1ae1fea3868c9f0