### PR TITLE
Update prompter mount effects

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -74,6 +74,7 @@ function Prompter() {
     window.addEventListener('mouseup', onUp)
   }
 
+  // Initial script loading on mount only
   useEffect(() => {
     const handleLoaded = (html) => {
       setContent(html)
@@ -181,12 +182,13 @@ function Prompter() {
   }, [transparent])
 
   // (re)open the prompter window when transparency changes
-  const openedRef = useRef(false)
+  // only after the component has mounted once
+  const mountedRef = useRef(false)
   useEffect(() => {
-    if (openedRef.current) {
+    if (mountedRef.current) {
       window.electronAPI.openPrompter(content, transparent)
     } else {
-      openedRef.current = true
+      mountedRef.current = true
     }
     // intentionally omit "content" from deps
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- clarify that script loading only runs once on mount
- rename ref for transparency reopen logic

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68707929f8fc832184fda7bb4118ea5c