### PR TITLE
Add toggle button to open dev console

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -276,7 +276,6 @@ app.whenReady().then(async () => {
   await waitForVite();
   ensureDirectories();
   createMainWindow();
-  createDevConsoleWindow();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -285,6 +284,13 @@ app.whenReady().then(async () => {
   });
 
   // --- IPC Handlers ---
+  ipcMain.on('open-dev-console', () => {
+    createDevConsoleWindow();
+    if (devConsoleWindow && !devConsoleWindow.isDestroyed()) {
+      devConsoleWindow.show();
+      devConsoleWindow.focus();
+    }
+  });
   ipcMain.on('open-prompter', async (_, html, transparentFlag) => {
     log('Received request to open prompter');
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -48,6 +48,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener('log-message', handler)
   },
 
+  openDevConsole: () => ipcRenderer.send('open-dev-console'),
+
   setPrompterAlwaysOnTop: (flag) =>
     ipcRenderer.send('set-prompter-always-on-top', flag),
 

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,28 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.dev-console-button {
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  background: #333;
+  border: none;
+  padding: 4px;
+  border-radius: 4px;
+  color: #e0e0e0;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.dev-console-button:hover {
+  background: #555;
+}
+
+.dev-console-button svg {
+  width: 20px;
+  height: 20px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,21 @@ import App from './App.jsx'
 import Prompter from './Prompter.jsx'
 import DevConsole from './DevConsole.jsx'
 
+function DevIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M8 12l3 3-3 3M13 15h3" />
+    </svg>
+  )
+}
+
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HashRouter>
@@ -15,6 +30,12 @@ createRoot(document.getElementById('root')).render(
         <Route path="/prompter" element={<Prompter />} />
         <Route path="/dev-console" element={<DevConsole />} />
       </Routes>
+      <button
+        className="dev-console-button"
+        onClick={() => window.electronAPI.openDevConsole()}
+      >
+        <DevIcon />
+      </button>
     </HashRouter>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- add IPC handler to open Dev Console on demand
- expose `openDevConsole` in preload
- add bottom-left button for dev console access
- update styling for new button
- dev console no longer auto-opens at startup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68707d7f2a9883218760b3c249263f29