### PR TITLE
Enable transparent click-through

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -243,6 +243,7 @@ async function createPrompterWindow(needTransparent = false) {
       skipTaskbar: true,
     });
     prompterWindowTransparent.setAlwaysOnTop(isAlwaysOnTop);
+    prompterWindowTransparent.setIgnoreMouseEvents(true, { forward: true });
     if (prompterWindowOpaque && !prompterWindowOpaque.isDestroyed()) {
       prompterWindowTransparent.setBounds(prompterWindowOpaque.getBounds());
     }
@@ -311,6 +312,7 @@ app.whenReady().then(async () => {
       prompterWindow = active;
       currentTransparent = desiredTransparent;
       active.setAlwaysOnTop(isAlwaysOnTop);
+      active.setIgnoreMouseEvents(desiredTransparent, { forward: true });
 
       ipcMain.once('prompter-ready', () => {
         if (active && !active.isDestroyed()) {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -177,8 +177,6 @@ function Prompter() {
 
     // force a repaint to avoid flicker when switching modes
     requestAnimationFrame(() => {})
-
-    window.electronAPI.prompterReady()
   }, [transparent])
 
   // (re)open the prompter window when transparency changes
@@ -189,6 +187,7 @@ function Prompter() {
       window.electronAPI.openPrompter(content, transparent)
     } else {
       mountedRef.current = true
+      window.electronAPI.prompterReady()
     }
     // intentionally omit "content" from deps
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary
- delay `prompterReady` until prompter window is mounted
- allow click-through on transparent prompter window

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6870835cbdbc8321b68639ff09bdc2a6