### PR TITLE
Remove transparency mode support

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -4,15 +4,12 @@ console.log('[PRELOAD] Preload script loaded ✅');
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Prompter controls
-  openPrompter: (html, transparent = false) =>
-    ipcRenderer.send('open-prompter', html, transparent),
+  openPrompter: (html) => ipcRenderer.send('open-prompter', html),
   onScriptLoaded: (callback) =>
     ipcRenderer.on('load-script', (_, data) => callback(data)),
   onScriptUpdated: (callback) =>
     ipcRenderer.on('update-script', (_, data) => callback(data)),
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
-  onTransparentChange: (callback) =>
-    ipcRenderer.on('set-transparent', (_, flag) => callback(flag)),
   getCurrentScript: () => ipcRenderer.invoke('get-current-script'),
   NEW_PROJECT_SENTINEL: '__NEW_PROJECT__',
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LeaderPrompt</title>
   </head>
-  <body style="background-color: transparent">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -54,7 +54,7 @@ function App() {
 
   const handleSendToPrompter = () => {
     if (scriptHtml) {
-      window.electronAPI.openPrompter(scriptHtml, false);
+      window.electronAPI.openPrompter(scriptHtml);
       setLoadedProject(selectedProject);
       setLoadedScript(selectedScript);
     }

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -14,7 +14,6 @@ function Prompter() {
   const [fontSize, setFontSize] = useState(2)
   const [mirrorX, setMirrorX] = useState(false)
   const [mirrorY, setMirrorY] = useState(false)
-  const [transparent, setTransparent] = useState(false)
   const [shadowStrength, setShadowStrength] = useState(8)
   const [strokeWidth, setStrokeWidth] = useState(0)
   const [lineHeight, setLineHeight] = useState(1.6)
@@ -32,7 +31,6 @@ function Prompter() {
     setFontSize(2)
     setMirrorX(false)
     setMirrorY(false)
-    setTransparent(false)
     setShadowStrength(8)
     setStrokeWidth(0)
     setLineHeight(1.6)
@@ -94,13 +92,6 @@ function Prompter() {
     return () => {}
   }, [])
 
-  useEffect(() => {
-    const handleTransparent = (flag) => {
-      setTransparent(flag)
-    }
-    window.electronAPI.onTransparentChange(handleTransparent)
-    return () => {}
-  }, [])
 
   useEffect(() => {
     if (!autoscroll || notecardMode) return undefined
@@ -170,30 +161,14 @@ function Prompter() {
     }
   }, [notecardMode])
 
-  // keep window visuals in sync with transparency mode
-  useEffect(() => {
-    window.electronAPI.setPrompterAlwaysOnTop(transparent)
-    const color = transparent ? 'transparent' : '#1e1e1e'
-    document.documentElement.style.backgroundColor = color
-    document.body.style.backgroundColor = color
-
-    // force a repaint to avoid flicker when switching modes
-    requestAnimationFrame(() => {})
-  }, [transparent])
-
-  // (re)open the prompter window when transparency changes
-  // only after the component has mounted once
+  // notify main process when the prompter component is ready
   const mountedRef = useRef(false)
   useEffect(() => {
-    if (mountedRef.current) {
-      window.electronAPI.openPrompter(content, transparent)
-    } else {
+    if (!mountedRef.current) {
       mountedRef.current = true
       window.electronAPI.prompterReady()
     }
-    // intentionally omit "content" from deps
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [transparent])
+  }, [])
 
   return (
     <div className="prompter-wrapper">
@@ -239,14 +214,6 @@ function Prompter() {
             }}
           />
           Notecard
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            checked={transparent}
-            onChange={() => setTransparent(!transparent)}
-          />
-          Transparent
         </label>
         <button className="settings-button" onClick={() => setSettingsOpen(!settingsOpen)}>
           ⚙
@@ -331,7 +298,7 @@ function Prompter() {
           lineHeight,
           textAlign,
           transform: `scale(${mirrorX ? -1 : 1}, ${mirrorY ? -1 : 1})`,
-          background: transparent ? 'transparent' : '#000',
+          background: '#000',
           color: '#e0e0e0',
           textShadow:
             shadowStrength > 0


### PR DESCRIPTION
## Summary
- drop support for the transparent prompter window
- simplify preloader API
- clean up Prompter component and UI

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_687087857248832188f162a7205383e5