### PR TITLE
Fix Electron prompter window readiness handling

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -252,8 +252,7 @@ app.whenReady().then(async () => {
       };
 
       ipcMain.once('prompter-ready', () => {
-        if (prompterWindow.isReadyToShow()) showWindow();
-        else prompterWindow.once('ready-to-show', showWindow);
+        prompterWindow.once('ready-to-show', showWindow);
       });
 
       prompterWindow.webContents.send('load-script', currentScriptHtml);


### PR DESCRIPTION
## Summary
- fix prompter window show logic by using the `ready-to-show` event

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687124d3a52c83218452d9be530dbca5