### PR TITLE
Fix prompter init sync

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -238,23 +238,23 @@ app.whenReady().then(async () => {
 
     currentScriptHtml = html;
 
-    await createPrompterWindow();
+    const showWindow = () => {
+      if (prompterWindow && !prompterWindow.isDestroyed()) {
+        prompterWindow.show();
+        prompterWindow.focus();
+        log('Prompter window shown');
+      }
+    };
+
+    if (!prompterWindow || prompterWindow.isDestroyed()) {
+      ipcMain.once('prompter-ready', showWindow);
+      await createPrompterWindow();
+    } else {
+      showWindow();
+    }
 
     if (prompterWindow && !prompterWindow.isDestroyed()) {
       prompterWindow.setAlwaysOnTop(isAlwaysOnTop);
-
-      const showWindow = () => {
-        if (prompterWindow && !prompterWindow.isDestroyed()) {
-          prompterWindow.show();
-          prompterWindow.focus();
-          log('Prompter window shown');
-        }
-      };
-
-      ipcMain.once('prompter-ready', () => {
-        prompterWindow.once('ready-to-show', showWindow);
-      });
-
       prompterWindow.webContents.send('load-script', currentScriptHtml);
     }
   });


### PR DESCRIPTION
## Summary
- fix the `open-prompter` IPC handler so the prompter window is shown reliably

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687127ddccf083219bb72a903cbed306