### PR TITLE
Ensure script editor spans full width

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -98,4 +98,5 @@
   overflow-y: auto;
   padding: 2rem;
   font-family: sans-serif;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- extend script editor area to use full width of the right panel

## Testing
- `npm test --silent` *(fails: no tests defined)*
- `npm run lint --silent` *(fails: missing '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871395ee8408321baf05d3a1ba5afbf