### PR TITLE
Update new script workflow with project selection modal

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -332,3 +332,11 @@ body {
   justify-content: flex-end;
   gap: var(--space-2);
 }
+
+.modal-window select {
+  padding: var(--space-2);
+  background: #111;
+  border: 1px solid #444;
+  color: #e0e0e0;
+  border-radius: 4px;
+}

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -2,8 +2,7 @@ import { useEffect, useState } from 'react';
 import ActionMenu from './ActionMenu';
 import NameModal from './NameModal';
 import MessageModal from './MessageModal';
-
-const NEW_PROJECT_SENTINEL = '__NEW_PROJECT__';
+import ProjectSelectModal from './ProjectSelectModal';
 
 function PencilIcon() {
   return (
@@ -59,6 +58,7 @@ function FileManager({
   const [collapsed, setCollapsed] = useState({});
   const [newScriptProject, setNewScriptProject] = useState(null);
   const [showProjectNameModal, setShowProjectNameModal] = useState(false);
+  const [showProjectSelectModal, setShowProjectSelectModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
   useEffect(() => {
@@ -102,13 +102,8 @@ function FileManager({
     await loadProjects();
   };
 
-  const handleNewScript = async () => {
-    const projectName = await window.electronAPI.selectProjectFolder();
-    if (projectName === NEW_PROJECT_SENTINEL) {
-      setShowProjectNameModal(true);
-    } else if (projectName) {
-      setNewScriptProject(projectName);
-    }
+  const handleNewScript = () => {
+    setShowProjectSelectModal(true);
   };
 
   const confirmNewProjectForScript = async (name) => {
@@ -124,6 +119,18 @@ function FileManager({
   };
 
   const cancelNewProjectForScript = () => setShowProjectNameModal(false);
+
+  const cancelProjectSelect = () => setShowProjectSelectModal(false);
+
+  const openNewProjectForScript = () => {
+    setShowProjectSelectModal(false);
+    setShowProjectNameModal(true);
+  };
+
+  const chooseExistingProject = (name) => {
+    setShowProjectSelectModal(false);
+    if (name) setNewScriptProject(name);
+  };
 
   const startRenameProject = (name) => {
     setRenamingScript(null);
@@ -332,6 +339,14 @@ function FileManager({
           </div>
         ))}
       </div>
+      {showProjectSelectModal && (
+        <ProjectSelectModal
+          projects={projects.map((p) => p.name)}
+          onCreateNew={openNewProjectForScript}
+          onSelect={chooseExistingProject}
+          onCancel={cancelProjectSelect}
+        />
+      )}
       {showProjectNameModal && (
         <NameModal
           title="New Project Name"

--- a/src/ProjectSelectModal.jsx
+++ b/src/ProjectSelectModal.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+
+function ProjectSelectModal({ projects = [], onCreateNew, onSelect, onCancel }) {
+  const [selected, setSelected] = useState(projects[0] || '');
+  const selectRef = useRef(null);
+
+  useEffect(() => {
+    if (selectRef.current) selectRef.current.focus();
+  }, []);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (selected) onSelect(selected);
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="modal-window">
+        <h3>Select Project</h3>
+        <button onClick={onCreateNew}>Create New Project</button>
+        {projects.length > 0 ? (
+          <select
+            ref={selectRef}
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            onKeyDown={handleKeyDown}
+          >
+            {projects.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <p>No projects available. Create a new one.</p>
+        )}
+        <div className="modal-actions">
+          <button onClick={onCancel}>Cancel</button>
+          <button onClick={() => onSelect(selected)} disabled={!selected}>
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ProjectSelectModal;


### PR DESCRIPTION
## Summary
- add `ProjectSelectModal` component
- update `FileManager` to use new modal for choosing the project when creating a script
- style modal `<select>` element

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687138daa8988321aa8d4d489cbe5927