### PR TITLE
Improve new script modal UX

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -132,6 +132,11 @@ function FileManager({
     if (name) setNewScriptProject(name);
   };
 
+  const backToProjectSelect = () => {
+    setNewScriptProject(null);
+    setShowProjectSelectModal(true);
+  };
+
   const startRenameProject = (name) => {
     setRenamingScript(null);
     setRenamingProject(name);
@@ -361,6 +366,7 @@ function FileManager({
           placeholder="Script name"
           onConfirm={confirmNewScript}
           onCancel={cancelNewScript}
+          onBack={backToProjectSelect}
         />
       )}
       {errorMessage && (

--- a/src/MessageModal.jsx
+++ b/src/MessageModal.jsx
@@ -13,8 +13,8 @@ function MessageModal({ title = 'Message', message, onClose }) {
   }, [onClose]);
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-window">
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-window" onClick={(e) => e.stopPropagation()}>
         {title && <h3>{title}</h3>}
         <p>{message}</p>
         <div className="modal-actions">

--- a/src/NameModal.jsx
+++ b/src/NameModal.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-function NameModal({ title, placeholder, onConfirm, onCancel }) {
+function NameModal({ title, placeholder, onConfirm, onCancel, onBack }) {
   const [value, setValue] = useState('');
   const inputRef = useRef(null);
 
@@ -19,8 +19,8 @@ function NameModal({ title, placeholder, onConfirm, onCancel }) {
   };
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-window">
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal-window" onClick={(e) => e.stopPropagation()}>
         <h3>{title}</h3>
         <input
           ref={inputRef}
@@ -31,6 +31,7 @@ function NameModal({ title, placeholder, onConfirm, onCancel }) {
           onKeyDown={handleKeyDown}
         />
         <div className="modal-actions">
+          {onBack && <button onClick={onBack}>Back</button>}
           <button onClick={onCancel}>Cancel</button>
           <button onClick={() => onConfirm(value.trim())}>OK</button>
         </div>

--- a/src/ProjectSelectModal.jsx
+++ b/src/ProjectSelectModal.jsx
@@ -19,23 +19,26 @@ function ProjectSelectModal({ projects = [], onCreateNew, onSelect, onCancel }) 
   };
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-window">
-        <h3>Select Project</h3>
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal-window" onClick={(e) => e.stopPropagation()}>
+        <h3>Select Script Location</h3>
         <button onClick={onCreateNew}>Create New Project</button>
         {projects.length > 0 ? (
-          <select
-            ref={selectRef}
-            value={selected}
-            onChange={(e) => setSelected(e.target.value)}
-            onKeyDown={handleKeyDown}
-          >
-            {projects.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
+          <>
+            <h4>Existing Projects</h4>
+            <select
+              ref={selectRef}
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              onKeyDown={handleKeyDown}
+            >
+              {projects.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </>
         ) : (
           <p>No projects available. Create a new one.</p>
         )}


### PR DESCRIPTION
## Summary
- show overlay dismiss and a header for existing projects in `ProjectSelectModal`
- allow closing modals by clicking outside
- add optional back button to `NameModal`
- wire up back button logic in `FileManager`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68713bb328908321ac7285601792c72e