### PR TITLE
Add collapsible sidebar controls to prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -113,23 +113,43 @@
   align-self: center;
 }
 
-.top-controls {
+.side-controls {
   position: fixed;
-  top: var(--space-3);
-  left: 50%;
-  transform: translateX(-50%);
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 220px;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
   display: flex;
+  flex-direction: column;
   gap: var(--space-2);
-  background: rgba(0, 0, 0, 0.6);
-  padding: var(--space-2) var(--space-3);
-  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: var(--space-4);
   z-index: 999;
   color: #e0e0e0;
 }
 
-.top-controls input[type='range'],
-.top-controls input[type='checkbox'] {
+.side-controls.open {
+  transform: translateX(0);
+}
+
+.side-controls input[type='range'],
+.side-controls input[type='checkbox'] {
   accent-color: var(--accent-color);
+}
+
+.sidebar-toggle {
+  position: fixed;
+  top: var(--space-3);
+  left: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+  padding: var(--space-2);
+  border-radius: 0 4px 4px 0;
 }
 
 .settings-button {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -10,7 +10,7 @@ function Prompter() {
   const [content, setContent] = useState('')
   const [autoscroll, setAutoscroll] = useState(false)
   const [speed, setSpeed] = useState(1)
-  const [margin, setMargin] = useState(100)
+  const [margin, setMargin] = useState(MARGIN_MAX)
   const [fontSize, setFontSize] = useState(2)
   const [mirrorX, setMirrorX] = useState(false)
   const [mirrorY, setMirrorY] = useState(false)
@@ -22,12 +22,13 @@ function Prompter() {
   const [slides, setSlides] = useState([])
   const [currentSlide, setCurrentSlide] = useState(0)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
   const containerRef = useRef(null)
 
   const resetDefaults = () => {
     setAutoscroll(false)
     setSpeed(1)
-    setMargin(100)
+    setMargin(MARGIN_MAX)
     setFontSize(2)
     setMirrorX(false)
     setMirrorY(false)
@@ -180,7 +181,14 @@ function Prompter() {
       <div className="resize-handle top-right" onMouseDown={(e) => startResize(e, 'top-right')} />
       <div className="resize-handle bottom-left" onMouseDown={(e) => startResize(e, 'bottom-left')} />
       <div className="resize-handle bottom-right" onMouseDown={(e) => startResize(e, 'bottom-right')} />
-      <div className="top-controls">
+      <button
+        className="sidebar-toggle"
+        style={{ left: sidebarOpen ? '220px' : '0' }}
+        onClick={() => setSidebarOpen(!sidebarOpen)}
+      >
+        {sidebarOpen ? '←' : '→'}
+      </button>
+      <div className={`side-controls ${sidebarOpen ? 'open' : ''}`}>
         <label>
           <input
             type="checkbox"


### PR DESCRIPTION
## Summary
- move prompter controls into a collapsible sidebar on the left
- toggle sidebar visibility with an arrow button
- default to widest margin so text won't touch the sidebar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68713e0a6f208321ab392da0d490fabe