### PR TITLE
Update prompter UI

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -174,6 +174,33 @@
   gap: var(--space-2);
 }
 
+.settings-wrapper {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 260px;
+  z-index: 998;
+}
+
+.advanced-panel {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 260px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: var(--space-4);
+  overflow-y: auto;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.advanced-panel.open {
+  transform: translateY(0);
+}
+
 .settings-panel label {
   display: block;
 }
@@ -181,4 +208,18 @@
 .settings-panel input[type='range'],
 .settings-panel input[type='checkbox'] {
   accent-color: var(--accent-color);
+}
+
+.toggle-btn {
+  background: #333;
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 4px;
+}
+
+.toggle-btn.active {
+  background: var(--accent-color);
+  color: #000;
 }


### PR DESCRIPTION
## Summary
- refactor prompter settings by adding `advanced` panel beneath main
- move margin slider into main settings and remove old heading
- adjust margin defaults
- use buttons for autoscroll and notecard toggles
- rename flip buttons for clarity

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687161f909f083218074cf1f15dda7c5