### PR TITLE
Fix prompting indicator on prompter close

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -203,6 +203,9 @@ async function createPrompterWindow() {
     prompterWindow.setAlwaysOnTop(isAlwaysOnTop)
     prompterWindow.on('closed', () => {
       prompterWindow = null
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('prompter-closed')
+      }
     })
     prompterWindow.loadURL(url)
     await new Promise((resolve) => prompterWindow.once('ready-to-show', resolve))
@@ -280,6 +283,9 @@ app.whenReady().then(async () => {
       prompterWindow.close();
     }
     prompterWindow = null;
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('prompter-closed');
+    }
     log('Prompter window closed');
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -53,6 +53,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   closePrompter: () => ipcRenderer.send('close-prompter'),
   minimizePrompter: () => ipcRenderer.send('minimize-prompter'),
 
+  onPrompterClosed: (callback) => {
+    const handler = () => callback()
+    ipcRenderer.on('prompter-closed', handler)
+    return () => ipcRenderer.removeListener('prompter-closed', handler)
+  },
+
   getPrompterBounds: () => ipcRenderer.invoke('get-prompter-bounds'),
   setPrompterBounds: (bounds) =>
     ipcRenderer.send('set-prompter-bounds', bounds),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
 
@@ -59,6 +59,16 @@ function App() {
       setLoadedScript(selectedScript);
     }
   };
+
+  useEffect(() => {
+    const cleanup = window.electronAPI.onPrompterClosed(() => {
+      setLoadedProject(null);
+      setLoadedScript(null);
+    });
+    return () => {
+      cleanup?.();
+    };
+  }, []);
 
   const handleScriptEdit = (html) => {
     setScriptHtml(html);


### PR DESCRIPTION
## Summary
- notify the main window when the prompter window closes
- expose `onPrompterClosed` in the preload API
- clear `loadedProject` and `loadedScript` when the event fires

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871622c86cc8321a654262ad4006c8d