### PR TITLE
Auto-open advanced panel

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -239,8 +239,13 @@ function Prompter() {
         <button
           className="settings-button"
           onClick={() => {
-            setSettingsOpen(!settingsOpen)
-            if (settingsOpen) setAdvancedOpen(false)
+            const next = !settingsOpen
+            setSettingsOpen(next)
+            if (next) {
+              setAdvancedOpen(true)
+            } else {
+              setAdvancedOpen(false)
+            }
           }}
         >
           ⚙
@@ -273,9 +278,7 @@ function Prompter() {
                 onChange={(e) => setMargin(parseInt(e.target.value, 10))}
               />
             </label>
-            <button onClick={() => setAdvancedOpen(!advancedOpen)}>
-              {advancedOpen ? 'Close Advanced' : 'Advanced'}
-            </button>
+            {/* Advanced panel now opens automatically when the settings button is pressed */}
             <button onClick={resetDefaults}>Reset to defaults</button>
           </div>
           )}


### PR DESCRIPTION
## Summary
- remove the button that toggled the advanced panel
- open advanced options automatically when pressing the settings button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871657587c883219cf4e12a0a8f58f4