### PR TITLE
Fix settings panels layout

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -159,27 +159,40 @@
   cursor: pointer;
 }
 
-.settings-panel {
+.advanced-toggle {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.settings-wrapper {
   position: fixed;
   top: 0;
-  right: 0;
+  left: 0;
+  width: 260px;
+  z-index: 998;
+}
+
+.settings-panel {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 260px;
   height: 100vh;
   background: rgba(0, 0, 0, 0.8);
   padding: var(--space-4);
   overflow-y: auto;
-  z-index: 998;
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
 }
 
-.settings-wrapper {
-  position: relative;
-  top: 0;
-  right: 0;
-  width: 260px;
-  z-index: 998;
+.settings-panel.open {
+  transform: translateX(0);
 }
 
 .advanced-panel {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -249,9 +249,7 @@ function Prompter() {
           onClick={() => {
             const next = !settingsOpen
             setSettingsOpen(next)
-            if (next) {
-              setAdvancedOpen(true)
-            } else {
+            if (!next) {
               setAdvancedOpen(false)
             }
           }}
@@ -263,7 +261,7 @@ function Prompter() {
       {(settingsOpen || advancedOpen) && (
         <div className="settings-wrapper" ref={settingsRef}>
           {settingsOpen && (
-            <div className="settings-panel">
+            <div className={`settings-panel ${settingsOpen ? 'open' : ''}`}>
           <h4>Text Styling</h4>
           <label>
             Font Size ({fontSize}rem):
@@ -286,8 +284,10 @@ function Prompter() {
                 onChange={(e) => setMargin(parseInt(e.target.value, 10))}
               />
             </label>
-            {/* Advanced panel now opens automatically when the settings button is pressed */}
             <button onClick={resetDefaults}>Reset to defaults</button>
+            <button className="advanced-toggle" onClick={() => setAdvancedOpen(!advancedOpen)}>
+              ⚙
+            </button>
           </div>
           )}
           {advancedOpen && (


### PR DESCRIPTION
## Summary
- move settings panel to slide out from the left
- add a toggle button inside settings panel for advanced settings
- tweak CSS for new panel positions

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6871686997a4832189fa4c1e71e3b20f