### PR TITLE
Adjust prompter panels

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -176,11 +176,10 @@
 }
 
 .settings-panel {
-  position: absolute;
+  position: relative;
   top: 0;
   left: 0;
-  width: 260px;
-  height: 100vh;
+  width: 100%;
   background: rgba(0, 0, 0, 0.8);
   padding: var(--space-4);
   overflow-y: auto;
@@ -199,7 +198,7 @@
   position: absolute;
   top: 100%;
   left: 0;
-  width: 260px;
+  width: 100%;
   background: rgba(0, 0, 0, 0.8);
   padding: var(--space-4);
   overflow-y: auto;

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -288,10 +288,8 @@ function Prompter() {
             <button className="advanced-toggle" onClick={() => setAdvancedOpen(!advancedOpen)}>
               ⚙
             </button>
-          </div>
-          )}
-          {advancedOpen && (
-            <div className={`advanced-panel ${advancedOpen ? 'open' : ''}`}>
+            {advancedOpen && (
+              <div className={`advanced-panel ${advancedOpen ? 'open' : ''}`}>
               <h4>Advanced Settings</h4>
               <label>
                 Line Height ({lineHeight})
@@ -336,7 +334,9 @@ function Prompter() {
                   <option value="justify">Justify</option>
                 </select>
               </label>
-            </div>
+              </div>
+            )}
+          </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- nest `advanced-panel` inside `settings-panel`
- tweak CSS so `settings-panel` is relative and `advanced-panel` sits underneath

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68716dc172188321b6bd1d9dd05bac2e