### PR TITLE
Add swipeable settings page in prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -233,3 +233,32 @@
   background: var(--accent-color);
   color: #000;
 }
+
+.settings-close {
+  position: absolute;
+  top: var(--space-2);
+  right: var(--space-2);
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+}
+
+.page-indicators {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}
+
+.page-indicators .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #666;
+  cursor: pointer;
+}
+
+.page-indicators .dot.active {
+  background: var(--accent-color);
+}


### PR DESCRIPTION
## Summary
- add page navigation to prompter settings
- close settings with escape key or close button
- show page indicators for multiple pages

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871a23aabdc8321b7aec4627362b377