### PR TITLE
Improve UI behaviour for script editor and file manager

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,7 @@ body {
 
 .left-panel {
   width: 300px;
+  min-width: 260px;
   background-color: #111;
   border-right: 1px solid #333;
   padding: calc(var(--space-4) + var(--space-1));
@@ -198,12 +199,13 @@ body {
 .script-button {
   flex-grow: 1;
   background: none;
-  border: none;
+  border: 1px solid transparent;
+  border-radius: 9999px;
   color: #e0e0e0;
   text-align: left;
-  padding: var(--space-1) var(--space-2);
+  padding: var(--space-1) var(--space-3);
   cursor: pointer;
-  transition: color 0.2s;
+  transition: color 0.2s, background-color 0.2s, border-color 0.2s;
 }
 
 .script-button:hover {
@@ -212,12 +214,18 @@ body {
 
 
 .script-item.loaded .script-button {
-  font-weight: bold;
-  color: #e0e0e0;
+  border-color: var(--accent-color);
 }
 
 .script-item.prompting .script-button {
-  color: var(--accent-color);
+  background-color: var(--accent-color);
+  color: #1e1e1e;
+}
+
+.script-item.loaded.prompting .script-button {
+  background-color: var(--accent-color);
+  color: #1e1e1e;
+  border-color: var(--accent-color);
 }
 
 .status-indicator {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,7 +70,19 @@ function App() {
     };
   }, []);
 
-  const handleScriptEdit = (html) => {
+  const handleScriptEdit = async (html) => {
+    if (!selectedProject && !selectedScript && html.trim()) {
+      const projectName = 'Quick Scripts';
+      await window.electronAPI.createNewProject(projectName);
+      const result = await window.electronAPI.createNewScript(
+        projectName,
+        'Untitled',
+      );
+      if (result && result.success) {
+        setSelectedProject(projectName);
+        setSelectedScript(result.scriptName);
+      }
+    }
     setScriptHtml(html);
     if (selectedProject && selectedScript) {
       if (saveTimeout.current) {

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
   background-color: #1e1e1e;
   color: #e0e0e0;
 }
@@ -22,7 +23,9 @@
 
 .header-logo {
   width: 120px;
-  margin-left: auto;
+  position: absolute;
+  bottom: var(--space-3);
+  right: var(--space-3);
 }
 
 
@@ -38,33 +41,28 @@
 }
 
 
-.load-placeholder {
-  flex-grow: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  
-  text-align: center;
-  font-size: 1.2rem;
-  color: #aaa;
-}
 
 .close-button {
   background: none;
   border: none;
-  color: #e0e0e0;
+  color: #aaa;
   cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  font-size: 0.9rem;
+  padding: 0 0.25rem;
+  font-size: 1rem;
 }
 
 .close-button:hover {
-  text-decoration: none;
+  color: var(--accent-color);
+}
+
+.script-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
 }
 
 .script-name {
-  text-align: center;
-  margin-bottom: 1rem;
   font-size: 1.2rem;
 }
 
@@ -77,22 +75,25 @@
 .send-button {
   padding: var(--space-3) calc(var(--space-2) * 3);
   font-size: 16px;
-  background-color: var(--accent-color);
+  background-color: #444;
   color: #e0e0e0;
   border: none;
   border-radius: 6px;
   cursor: pointer;
+  transition: background-color 0.2s;
 }
 
 .send-button:hover {
   background-color: var(--accent-color);
+  color: #1e1e1e;
 }
 
 .script-content {
   outline: none;
   flex-grow: 1;
   overflow-y: auto;
-  padding: 2rem;
+  padding: 2.5rem;
+  background-color: #161616;
   font-family: sans-serif;
   width: 100%;
 }

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -38,17 +38,25 @@ function ScriptViewer({
       <div className="viewer-header">
         <div className="header-left">
           <h2 className="header-title">Script Viewer</h2>
-          {!showLogo && (
-            <button className="close-button" onClick={onClose}>Close</button>
-          )}
         </div>
         <img src={leaderLogo} alt="LeaderPrompt Logo" className="header-logo" />
       </div>
       {scriptName && (
-        <div className="script-name">{scriptName.replace(/\.[^/.]+$/, '')}</div>
+        <div className="script-name-row">
+          <div className="script-name">
+            {scriptName.replace(/\.[^/.]+$/, '')}
+          </div>
+          <button
+            className="close-button"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
       )}
       {showLogo ? (
-        <div className="load-placeholder">Please load a script</div>
+        <div className="script-content" ref={contentRef} contentEditable onInput={handleInput} onBlur={handleBlur} />
       ) : (
         <>
           <div


### PR DESCRIPTION
## Summary
- tweak script viewer styles and layout
- add Quick Scripts auto-creation on typing
- update pill-style cues in file list
- ensure left panel has room for buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6871a89c02208321988c2e22e2238f42