### PR TITLE
Revert quick script creation

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 import ActionMenu from './ActionMenu';
 import NameModal from './NameModal';
 import MessageModal from './MessageModal';
@@ -42,13 +42,13 @@ function TrashIcon() {
   );
 }
 
-function FileManager({
+const FileManager = forwardRef(function FileManager({
   onScriptSelect,
   loadedProject,
   loadedScript,
   currentProject,
   currentScript,
-}) {
+}, ref) {
   const [projects, setProjects] = useState([]);
   const [newProjectName, setNewProjectName] = useState('');
   const [showNewProjectInput, setShowNewProjectInput] = useState(false);
@@ -60,6 +60,7 @@ function FileManager({
   const [showProjectNameModal, setShowProjectNameModal] = useState(false);
   const [showProjectSelectModal, setShowProjectSelectModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
+
 
   useEffect(() => {
     loadProjects();
@@ -136,6 +137,11 @@ function FileManager({
     setNewScriptProject(null);
     setShowProjectSelectModal(true);
   };
+
+  useImperativeHandle(ref, () => ({
+    newScript: handleNewScript,
+    reload: loadProjects,
+  }));
 
   const startRenameProject = (name) => {
     setRenamingScript(null);
@@ -372,7 +378,7 @@ function FileManager({
       )}
     </div>
   );
-}
+});
 
 export default FileManager;
 

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -99,3 +99,26 @@
   width: 100%;
   min-height: 100%;
 }
+
+.load-placeholder {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  font-size: 1.2rem;
+  color: #aaa;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--accent-color);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+}
+
+.link-button:hover {
+  text-decoration: underline;
+}

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -8,6 +8,8 @@ function ScriptViewer({
   onSend,
   onEdit,
   onClose,
+  onCreate,
+  onLoad,
 }) {
   const contentRef = useRef(null);
 
@@ -56,7 +58,17 @@ function ScriptViewer({
         </div>
       )}
       {showLogo ? (
-        <div className="script-content" ref={contentRef} contentEditable onInput={handleInput} onBlur={handleBlur} />
+        <div className="load-placeholder">
+          Please{' '}
+          <button className="link-button" onClick={onLoad}>
+            Load
+          </button>{' '}
+          or{' '}
+          <button className="link-button" onClick={onCreate}>
+            Create
+          </button>{' '}
+          a Script
+        </div>
       ) : (
         <>
           <div


### PR DESCRIPTION
## Summary
- remove automatic 'Quick Scripts' creation from the editor
- add buttons to create or load scripts when none are open
- expose file manager functions via a ref

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6871cdb8346c832191c3b198e20b9e4a