### PR TITLE
Handle new script creation failure

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -190,10 +190,10 @@ const FileManager = forwardRef(function FileManager({
 
   const confirmNewScript = async (name) => {
     const projectName = newScriptProject;
-    setNewScriptProject(null);
     if (!name || !projectName) return;
     const result = await window.electronAPI.createNewScript(projectName, name);
     if (result && result.success) {
+      setNewScriptProject(null);
       await loadProjects();
       onScriptSelect(projectName, result.scriptName);
     } else {


### PR DESCRIPTION
## Summary
- keep the new script modal open if creation fails
- only clear newScriptProject when script is successfully created

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6871d66defa4832181eb775dad22a118