### PR TITLE
Improve new script creation

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -463,9 +463,17 @@ app.whenReady().then(async () => {
         finalName += '.docx';
       }
       const rootName = finalName.replace(/\.docx$/i, '');
+
+      const existingFiles = await fs.promises.readdir(base);
+      const names = new Set(
+        existingFiles
+          .filter((f) => f.toLowerCase().endsWith('.docx'))
+          .map((f) => f.replace(/\.docx$/i, '')),
+      );
+
       let candidate = rootName;
       let counter = 1;
-      while (fs.existsSync(path.join(base, `${candidate}.docx`))) {
+      while (names.has(candidate)) {
         candidate = `${rootName} ${counter}`;
         counter += 1;
       }


### PR DESCRIPTION
## Summary
- ensure project directory is scanned once when creating a new script
- generate script names in memory based on existing docx files

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871d64de99c83219f6d1510048fed45