### PR TITLE
Fix modals rendering inside FileManager

### DIFF
--- a/src/MessageModal.jsx
+++ b/src/MessageModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 function MessageModal({ title = 'Message', message, onClose }) {
   useEffect(() => {
@@ -12,7 +13,7 @@ function MessageModal({ title = 'Message', message, onClose }) {
     return () => window.removeEventListener('keydown', handle);
   }, [onClose]);
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-window" onClick={(e) => e.stopPropagation()}>
         {title && <h3>{title}</h3>}
@@ -21,7 +22,8 @@ function MessageModal({ title = 'Message', message, onClose }) {
           <button onClick={onClose}>OK</button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/src/NameModal.jsx
+++ b/src/NameModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 function NameModal({ title, placeholder, onConfirm, onCancel, onBack }) {
   const [value, setValue] = useState('');
@@ -18,7 +19,7 @@ function NameModal({ title, placeholder, onConfirm, onCancel, onBack }) {
     }
   };
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={onCancel}>
       <div className="modal-window" onClick={(e) => e.stopPropagation()}>
         <h3>{title}</h3>
@@ -36,7 +37,8 @@ function NameModal({ title, placeholder, onConfirm, onCancel, onBack }) {
           <button onClick={() => onConfirm(value.trim())}>OK</button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/src/ProjectSelectModal.jsx
+++ b/src/ProjectSelectModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 function ProjectSelectModal({ projects = [], onCreateNew, onSelect, onCancel }) {
   const [selected, setSelected] = useState(projects[0] || '');
@@ -18,7 +19,7 @@ function ProjectSelectModal({ projects = [], onCreateNew, onSelect, onCancel }) 
     }
   };
 
-  return (
+  return createPortal(
     <div className="modal-overlay" onClick={onCancel}>
       <div className="modal-window" onClick={(e) => e.stopPropagation()}>
         <h3>Select Script Location</h3>
@@ -49,7 +50,8 @@ function ProjectSelectModal({ projects = [], onCreateNew, onSelect, onCancel }) 
           </button>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body
   );
 }
 


### PR DESCRIPTION
## Summary
- render NameModal, MessageModal and ProjectSelectModal via `ReactDOM.createPortal`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687302d41e1883219c6e7b5d484f3a39