### PR TITLE
Move logo to main layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,6 +16,7 @@ body {
   display: flex;
   height: 100vh;
   overflow: hidden;
+  position: relative;
 }
 
 .left-panel {
@@ -294,5 +295,12 @@ body {
 
 .menu li button:hover {
   background: #333;
+}
+
+.main-logo {
+  width: 120px;
+  position: absolute;
+  bottom: var(--space-3);
+  right: var(--space-3);
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import './App.css';
 import { useState, useRef, useEffect } from 'react';
 import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
+import leaderLogo from './assets/LeaderPass-Logo-white.png';
 
 function App() {
   const [selectedScript, setSelectedScript] = useState(null);
@@ -143,6 +144,7 @@ function App() {
           onLoad={handleLoadRequest}
         />
       </div>
+      <img src={leaderLogo} alt="LeaderPrompt Logo" className="main-logo" />
     </div>
   );
 }

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -22,12 +22,6 @@
   gap: 0.5rem;
 }
 
-.header-logo {
-  width: 120px;
-  position: absolute;
-  bottom: var(--space-3);
-  right: var(--space-3);
-}
 
 
 .script-viewer-content {

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -1,5 +1,4 @@
 import './ScriptViewer.css';
-import leaderLogo from './assets/LeaderPass-Logo-white.png';
 import { useEffect, useRef } from 'react';
 function ScriptViewer({
   scriptHtml,
@@ -41,7 +40,6 @@ function ScriptViewer({
         <div className="header-left">
           <h2 className="header-title">Script Viewer</h2>
         </div>
-        <img src={leaderLogo} alt="LeaderPrompt Logo" className="header-logo" />
       </div>
       {scriptName && (
         <div className="script-name-row">


### PR DESCRIPTION
## Summary
- move LeaderPass logo out of ScriptViewer and into main layout
- update layout and styles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68731a175e9483219899d207167eb08e