### PR TITLE
Use flexbox layout for sidebar, remove dragging

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,26 +20,15 @@ body {
 }
 
 .left-panel {
-  width: 300px;
-  min-width: 260px;
+  flex: 0 0 clamp(240px, 25%, 300px);
   background-color: #111;
   border-right: 1px solid #333;
   padding: calc(var(--space-4) + var(--space-1));
-}
-
-.divider {
-  width: 5px;
-  cursor: col-resize;
-  background-color: #333;
-  user-select: none;
-}
-
-.divider:hover {
-  background-color: #555;
+  overflow: hidden;
 }
 
 .right-panel {
-  flex-grow: 1;
+  flex: 1;
   display: flex;
   flex-direction: column;
   padding: calc(var(--space-4) * 2.5);
@@ -90,10 +79,12 @@ body {
   padding: var(--space-2) var(--space-4);
   background-color: #333;
   color: #e0e0e0;
-
   border: none;
   border-radius: 6px;
   cursor: pointer;
+  white-space: nowrap;
+  min-width: max-content;
+  overflow: hidden;
 }
 
 .file-manager-header button:hover {
@@ -162,6 +153,9 @@ body {
   margin: 0;
   font-size: 16px;
   color: #ccc;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .project-header button:not(.toggle-button) {
@@ -206,6 +200,9 @@ body {
   padding: var(--space-1) var(--space-3);
   cursor: pointer;
   transition: color 0.2s, background-color 0.2s, border-color 0.2s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .script-button:hover {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,37 +9,7 @@ function App() {
   const [selectedProject, setSelectedProject] = useState(null);
   const [loadedScript, setLoadedScript] = useState(null);
   const [loadedProject, setLoadedProject] = useState(null);
-  const [leftWidth, setLeftWidth] = useState(300);
-  const leftRef = useRef(null);
   const fileManagerRef = useRef(null);
-  const isDragging = useRef(false);
-
-  const onDrag = (e) => {
-    if (!isDragging.current) return;
-    const newWidth = Math.min(
-      Math.max(150, e.clientX),
-      window.innerWidth - 150,
-    );
-    if (leftRef.current) {
-      leftRef.current.style.width = `${newWidth}px`;
-    }
-  };
-
-  const stopDrag = () => {
-    if (!isDragging.current) return;
-    isDragging.current = false;
-    window.removeEventListener('mousemove', onDrag);
-    window.removeEventListener('mouseup', stopDrag);
-    if (leftRef.current) {
-      setLeftWidth(parseInt(leftRef.current.style.width, 10));
-    }
-  };
-
-  const startDrag = () => {
-    isDragging.current = true;
-    window.addEventListener('mousemove', onDrag);
-    window.addEventListener('mouseup', stopDrag);
-  };
 
   const handleScriptSelect = (projectName, scriptName) => {
     setSelectedProject(projectName);
@@ -71,7 +41,7 @@ function App() {
 
   return (
     <div className="main-layout">
-      <div className="left-panel" ref={leftRef} style={{ width: leftWidth }}>
+      <div className="left-panel">
         <FileManager
           ref={fileManagerRef}
           onScriptSelect={handleScriptSelect}
@@ -81,7 +51,6 @@ function App() {
           currentScript={selectedScript}
         />
       </div>
-      <div className="divider" onMouseDown={startDrag} />
       <div className="right-panel">
         <ScriptViewer
           projectName={selectedProject}

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -59,6 +59,9 @@
 
 .script-name {
   font-size: 1.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .send-button-wrapper {


### PR DESCRIPTION
## Summary
- switch to clamp-based sidebar width
- remove draggable divider and related logic
- prevent control squishing and truncate long names

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68731cef5190832185f43f242f339bff