### PR TITLE
Wrap script viewer content

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -27,7 +27,7 @@
 .script-viewer-content {
   flex-grow: 1;
   overflow-y: auto;
-  padding: 2rem;
+  padding: 2.5rem;
   background-color: #1e1e1e;
   line-height: 1.6;
   font-size: 16px;
@@ -90,7 +90,7 @@
   outline: none;
   flex-grow: 1;
   overflow-y: auto;
-  padding: 2.5rem;
+  padding: 0;
   background-color: #161616;
   font-family: sans-serif;
   width: 100%;

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -122,34 +122,36 @@ function ScriptViewer({
           </button>
         </div>
       )}
-      {showLogo ? (
-        <div className="load-placeholder">
-          Please{' '}
-          <button className="link-button" onClick={onLoad}>
-            Load
-          </button>{' '}
-          or{' '}
-          <button className="link-button" onClick={onCreate}>
-            Create
-          </button>{' '}
-          a Script
-        </div>
-      ) : (
-        <>
-          <div
-            ref={contentRef}
-            className="script-content"
-            contentEditable
-            onBlur={handleBlur}
-            onInput={handleInput}
-          />
-          <div className="send-button-wrapper">
-            <button className="send-button" onClick={handleSend}>
-              Let&apos;s Go!
-            </button>
+      <div className="script-viewer-content">
+        {showLogo ? (
+          <div className="load-placeholder">
+            Please{' '}
+            <button className="link-button" onClick={onLoad}>
+              Load
+            </button>{' '}
+            or{' '}
+            <button className="link-button" onClick={onCreate}>
+              Create
+            </button>{' '}
+            a Script
           </div>
-        </>
-      )}
+        ) : (
+          <>
+            <div
+              ref={contentRef}
+              className="script-content"
+              contentEditable
+              onBlur={handleBlur}
+              onInput={handleInput}
+            />
+            <div className="send-button-wrapper">
+              <button className="send-button" onClick={handleSend}>
+                Let&apos;s Go!
+              </button>
+            </div>
+          </>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- wrap placeholder and script editor in a new `.script-viewer-content` container so they share layout
- adjust CSS so `.script-viewer-content` provides padding
- remove padding from `.script-content`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68731f52b0fc83219e43d46eb99907d5