### PR TITLE
Fix left panel clipping

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,8 @@ body {
   background-color: #111;
   border-right: 1px solid #333;
   padding: calc(var(--space-4) + var(--space-1));
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: visible;
 }
 
 .right-panel {
@@ -73,6 +74,7 @@ body {
 .header-buttons {
   display: flex;
   gap: var(--space-2);
+  flex-wrap: wrap;
 }
 
 .file-manager-header button {


### PR DESCRIPTION
## Summary
- prevent content from getting clipped in the left panel
- make header buttons wrap so they remain visible

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687320b9da3c8321b33db83a90bc7616