### PR TITLE
Add delayed tooltip for script buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -203,10 +203,25 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  position: relative;
 }
 
 .script-button:hover {
   color: var(--accent-color);
+}
+
+.script-tooltip {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #333;
+  color: #e0e0e0;
+  padding: 2px 6px;
+  font-size: 12px;
+  white-space: nowrap;
+  border-radius: 4px;
+  margin-top: 2px;
+  z-index: 5;
 }
 
 

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -1,4 +1,10 @@
-import { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
+import {
+  useEffect,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+} from 'react';
 import ActionMenu from './ActionMenu';
 
 function PencilIcon() {
@@ -53,6 +59,8 @@ const FileManager = forwardRef(function FileManager({
   const [renamingScript, setRenamingScript] = useState(null);
   const [renameValue, setRenameValue] = useState('');
   const [collapsed, setCollapsed] = useState({});
+  const [tooltipScript, setTooltipScript] = useState(null);
+  const tooltipTimerRef = useRef(null);
 
 
   useEffect(() => {
@@ -180,6 +188,18 @@ const FileManager = forwardRef(function FileManager({
     }));
   };
 
+  const handleScriptMouseEnter = (scriptName) => {
+    tooltipTimerRef.current = setTimeout(() => {
+      setTooltipScript(scriptName);
+    }, 2000);
+  };
+
+  const handleScriptMouseLeave = () => {
+    clearTimeout(tooltipTimerRef.current);
+    tooltipTimerRef.current = null;
+    setTooltipScript(null);
+  };
+
   return (
     <div className="file-manager">
       <div className="file-manager-header">
@@ -274,8 +294,13 @@ const FileManager = forwardRef(function FileManager({
                         <button
                           className="script-button"
                           onClick={() => onScriptSelect(project.name, script)}
+                          onMouseEnter={() => handleScriptMouseEnter(script)}
+                          onMouseLeave={handleScriptMouseLeave}
                         >
                           {script.replace(/\.[^/.]+$/, '')}
+                          {tooltipScript === script && (
+                            <span className="script-tooltip">{script}</span>
+                          )}
                         </button>
                         <div className="script-actions">
                           <button


### PR DESCRIPTION
## Summary
- show entire file name in `FileManager` when hovering over a script
- style tooltip in `App.css`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687320c299148321a72cb84dac75739d