### PR TITLE
Fix left panel clipping

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,11 +20,12 @@ body {
 }
 
 .left-panel {
-  flex: 0 0 clamp(240px, 25%, 300px);
+  flex: 0 0 clamp(280px, 25%, 320px);
   background-color: #111;
   border-right: 1px solid #333;
   padding: calc(var(--space-4) + var(--space-1));
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: visible;
 }
 
 .right-panel {


### PR DESCRIPTION
## Summary
- prevent content from getting clipped in the left panel
- keep header buttons side by side by widening the left panel

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_687320b9da3c8321b33db83a90bc7616