### PR TITLE
Inline project action icons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -174,6 +174,16 @@ body {
   background: #555;
 }
 
+.project-actions {
+  display: none;
+  margin-left: auto;
+  gap: var(--space-1);
+}
+
+.project-header:hover .project-actions {
+  display: flex;
+}
+
 .project-group.collapsed ul {
   display: none;
 }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -5,7 +5,7 @@ import {
   useImperativeHandle,
   useRef,
 } from 'react';
-import ActionMenu from './ActionMenu';
+// The old project ActionMenu has been replaced with inline buttons
 
 function PencilIcon() {
   return (
@@ -40,6 +40,25 @@ function TrashIcon() {
         strokeLinecap="round"
         strokeLinejoin="round"
         d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"
+      />
+    </svg>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 4.5v15m7.5-7.5h-15"
       />
     </svg>
   );
@@ -252,13 +271,29 @@ const FileManager = forwardRef(function FileManager({
                     </button>
                     <h4>{project.name}</h4>
                   </div>
-                  <ActionMenu
-                    actions={[
-                      { label: 'Add File', onClick: () => handleImportClick(project.name) },
-                      { label: 'Rename', onClick: () => startRenameProject(project.name) },
-                      { label: 'Delete', onClick: () => handleDeleteProject(project.name) },
-                    ]}
-                  />
+                  <div className="project-actions">
+                    <button
+                      className="icon-button"
+                      onClick={() => handleImportClick(project.name)}
+                      aria-label="Add Script"
+                    >
+                      <PlusIcon />
+                    </button>
+                    <button
+                      className="icon-button"
+                      onClick={() => startRenameProject(project.name)}
+                      aria-label="Rename"
+                    >
+                      <PencilIcon />
+                    </button>
+                    <button
+                      className="icon-button"
+                      onClick={() => handleDeleteProject(project.name)}
+                      aria-label="Delete"
+                    >
+                      <TrashIcon />
+                    </button>
+                  </div>
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary
- replace hamburger ActionMenu with inline icon buttons
- add new PlusIcon component
- style project action buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687326d90498832193186d3b22e5b8ba