### PR TITLE
Align header layout across panels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,8 +60,8 @@ body {
 
 .file-manager-header {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: center;
   gap: var(--space-2);
   margin-bottom: var(--space-4);
   padding: 0.5rem;
@@ -69,6 +69,12 @@ body {
 
 .file-manager-header .header-title {
   margin: 0;
+}
+
+.file-manager-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .header-buttons {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -222,7 +222,9 @@ const FileManager = forwardRef(function FileManager({
   return (
     <div className="file-manager">
       <div className="file-manager-header">
-        <h2 className="header-title">Projects</h2>
+        <div className="header-left">
+          <h2 className="header-title">Projects</h2>
+        </div>
         <div className="header-buttons">
           <button onClick={handleNewScript}>+ New Script</button>
           <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>


### PR DESCRIPTION
## Summary
- restructure FileManager header to match ScriptViewer structure
- update FileManager header styles for row layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68732bdd2df88321a52a7fb58d5de761