### PR TITLE
Align header layout across panels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -60,10 +60,10 @@ body {
 
 .file-manager-header {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  justify-content: space-between;
+  align-items: center;
   gap: var(--space-2);
-  margin-bottom: var(--space-4);
+  margin-bottom: var(--space-2);
   padding: 0.5rem;
 }
 
@@ -71,10 +71,20 @@ body {
   margin: 0;
 }
 
+.file-manager-header .header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .header-buttons {
   display: flex;
   gap: var(--space-2);
   flex-wrap: wrap;
+}
+
+.file-manager .header-buttons {
+  margin-bottom: var(--space-4);
 }
 
 .file-manager-header button {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -222,13 +222,15 @@ const FileManager = forwardRef(function FileManager({
   return (
     <div className="file-manager">
       <div className="file-manager-header">
-        <h2 className="header-title">Projects</h2>
-        <div className="header-buttons">
-          <button onClick={handleNewScript}>+ New Script</button>
-          <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>
-            + New Project
-          </button>
+        <div className="header-left">
+          <h2 className="header-title">Projects</h2>
         </div>
+      </div>
+      <div className="header-buttons">
+        <button onClick={handleNewScript}>+ New Script</button>
+        <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>
+          + New Project
+        </button>
       </div>
 
       {showNewProjectInput && (

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -50,7 +50,7 @@
   color: var(--accent-color);
 }
 
-.script-name-row {
+.script-viewer .header-buttons {
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -109,7 +109,7 @@ function ScriptViewer({
         </div>
       </div>
       {scriptName && (
-        <div className="script-name-row">
+        <div className="header-buttons">
           <div className="script-name">
             {scriptName.replace(/\.[^/.]+$/, '')}
           </div>


### PR DESCRIPTION
## Summary
- restructure FileManager header to keep action row below title
- place ScriptViewer close button row in matching `header-buttons` container
- update CSS for both components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68732bdd2df88321a52a7fb58d5de761