### PR TITLE
Add cancellation logic to ScriptViewer

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -17,11 +17,14 @@ function ScriptViewer({
   const saveTimeout = useRef(null);
 
   useEffect(() => {
+    let cancelled = false;
     if (projectName && scriptName) {
       window.electronAPI
         .loadScript(projectName, scriptName)
         .then((html) => {
-          setScriptHtml(html);
+          if (!cancelled) {
+            setScriptHtml(html);
+          }
         })
         .catch((err) => {
           console.error('Failed to load script:', err);
@@ -29,15 +32,18 @@ function ScriptViewer({
     } else {
       setScriptHtml(null);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [projectName, scriptName]);
 
   useEffect(() => {
-    if (
-      contentRef.current &&
-      scriptHtml !== null &&
-      contentRef.current.innerHTML !== scriptHtml
-    ) {
-      contentRef.current.innerHTML = scriptHtml;
+    if (contentRef.current) {
+      if (scriptHtml !== null && contentRef.current.innerHTML !== scriptHtml) {
+        contentRef.current.innerHTML = scriptHtml;
+      } else if (scriptHtml === null) {
+        contentRef.current.innerHTML = '';
+      }
     }
   }, [scriptHtml]);
 


### PR DESCRIPTION
## Summary
- prevent `setScriptHtml` from firing on an unmounted component by tracking a `cancelled` flag in `ScriptViewer`
- clear markup from the viewer when there is no script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68732f5dbde48321b1c463b940aa78d3