### PR TITLE
Move send button to parent

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -338,3 +338,29 @@ body {
   right: var(--space-3);
 }
 
+/* Send button positioned at the bottom of the right panel */
+.send-button-container {
+  position: sticky;
+  bottom: var(--space-3);
+  display: flex;
+  justify-content: center;
+  padding-top: var(--space-3);
+  background-color: #1e1e1e;
+}
+
+.send-button {
+  padding: var(--space-3) calc(var(--space-2) * 3);
+  font-size: 16px;
+  background-color: #444;
+  color: #e0e0e0;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.send-button:hover {
+  background-color: var(--accent-color);
+  color: #1e1e1e;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ function App() {
   const [loadedScript, setLoadedScript] = useState(null);
   const [loadedProject, setLoadedProject] = useState(null);
   const fileManagerRef = useRef(null);
+  const sendCallbackRef = useRef(null);
 
   const handleScriptSelect = (projectName, scriptName) => {
     setSelectedProject(projectName);
@@ -62,7 +63,18 @@ function App() {
           onCloseViewer={handleViewerClose}
           onCreate={handleCreateRequest}
           onLoad={handleLoadRequest}
+          onSend={(cb) => {
+            sendCallbackRef.current = cb;
+          }}
         />
+        <div className="send-button-container">
+          <button
+            className="send-button"
+            onClick={() => sendCallbackRef.current && sendCallbackRef.current()}
+          >
+            Let&apos;s Go!
+          </button>
+        </div>
       </div>
       <img src={leaderLogo} alt="LeaderPrompt Logo" className="main-logo" />
     </div>

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -64,27 +64,6 @@
   text-overflow: ellipsis;
 }
 
-.send-button-wrapper {
-  display: flex;
-  justify-content: center;
-  margin: 1rem 0 2rem;
-}
-
-.send-button {
-  padding: var(--space-3) calc(var(--space-2) * 3);
-  font-size: 16px;
-  background-color: #444;
-  color: #e0e0e0;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.send-button:hover {
-  background-color: var(--accent-color);
-  color: #1e1e1e;
-}
 
 .script-content {
   outline: none;

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -1,5 +1,5 @@
 import './ScriptViewer.css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 
 function ScriptViewer({
   projectName,
@@ -11,6 +11,7 @@ function ScriptViewer({
   onCloseViewer,
   onCreate,
   onLoad,
+  onSend,
 }) {
   const [scriptHtml, setScriptHtml] = useState(null);
   const contentRef = useRef(null);
@@ -75,12 +76,18 @@ function ScriptViewer({
     }
   };
 
-  const handleSend = () => {
+  const handleSend = useCallback(() => {
     if (scriptHtml) {
       window.electronAPI.openPrompter(scriptHtml);
       onPrompterOpen?.(projectName, scriptName);
     }
-  };
+  }, [scriptHtml, projectName, scriptName, onPrompterOpen]);
+
+  useEffect(() => {
+    if (onSend) {
+      onSend(() => handleSend());
+    }
+  }, [onSend, handleSend]);
 
   useEffect(() => {
     const cleanup = window.electronAPI.onPrompterClosed(() => {
@@ -150,11 +157,6 @@ function ScriptViewer({
               onBlur={handleBlur}
               onInput={handleInput}
             />
-            <div className="send-button-wrapper">
-              <button className="send-button" onClick={handleSend}>
-                Let&apos;s Go!
-              </button>
-            </div>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- expose `onSend` callback from `ScriptViewer`
- relocate send button to `App` and wire it up
- drop old button markup and styles
- add sticky button styling for the right panel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687514f935448321b5129934399446f7