### PR TITLE
Add sortable project list

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -123,7 +123,7 @@ function getProjectMetadata() {
 function updateProjectMetadata(projectName) {
   const metadata = getProjectMetadata();
   if (!metadata.projects.some((p) => p.name === projectName)) {
-    metadata.projects.push({ name: projectName });
+    metadata.projects.push({ name: projectName, added: Date.now() });
     fs.writeFileSync(getProjectMetadataPath(), JSON.stringify(metadata, null, 2));
     log(`Metadata updated with new project: ${projectName}`);
   }
@@ -325,6 +325,8 @@ app.whenReady().then(async () => {
       const baseDir = getProjectsPath();
       if (!fs.existsSync(baseDir)) return [];
 
+      const metadata = getProjectMetadata();
+
       const projects = fs.readdirSync(baseDir).filter((file) => {
         const fullPath = path.join(baseDir, file);
         return fs.statSync(fullPath).isDirectory();
@@ -333,7 +335,9 @@ app.whenReady().then(async () => {
       const result = projects.map((projectName) => {
         const scriptsDir = path.join(baseDir, projectName);
         const scripts = fs.readdirSync(scriptsDir).filter((file) => file.endsWith('.docx'));
-        return { name: projectName, scripts };
+        const meta = metadata.projects.find((p) => p.name === projectName);
+        const added = meta?.added || 0;
+        return { name: projectName, scripts, added };
       });
 
       return result;

--- a/src/App.css
+++ b/src/App.css
@@ -99,6 +99,20 @@ body {
   overflow: hidden;
 }
 
+.sort-select {
+  padding: var(--space-2) var(--space-4);
+  background-color: #333;
+  color: #e0e0e0;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.sort-select option {
+  background-color: #333;
+  color: #e0e0e0;
+}
+
 .file-manager-header button:hover {
   background-color: var(--accent-color);
 }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useRef,
+  useMemo,
 } from 'react';
 // The old project ActionMenu has been replaced with inline buttons
 
@@ -80,6 +81,18 @@ const FileManager = forwardRef(function FileManager({
   const [collapsed, setCollapsed] = useState({});
   const [tooltipScript, setTooltipScript] = useState(null);
   const tooltipTimerRef = useRef(null);
+  const [sortBy, setSortBy] = useState('date');
+
+  const sortedProjects = useMemo(() => {
+    const arr = [...projects];
+    arr.sort((a, b) => {
+      if (sortBy === 'name') {
+        return a.name.localeCompare(b.name);
+      }
+      return (b.added || 0) - (a.added || 0);
+    });
+    return arr;
+  }, [projects, sortBy]);
 
 
   useEffect(() => {
@@ -227,6 +240,14 @@ const FileManager = forwardRef(function FileManager({
         </div>
       </div>
       <div className="header-buttons">
+        <select
+          className="sort-select"
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value)}
+        >
+          <option value="date">Date Added</option>
+          <option value="name">Name</option>
+        </select>
         <button onClick={handleNewScript}>+ New Script</button>
         <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>
           + New Project
@@ -246,7 +267,7 @@ const FileManager = forwardRef(function FileManager({
       )}
 
       <div className="file-manager-list">
-        {projects.map((project) => (
+        {sortedProjects.map((project) => (
           <div
             className={`project-group${collapsed[project.name] ? ' collapsed' : ''}`}
             key={project.name}


### PR DESCRIPTION
## Summary
- allow frontend to sort projects by date added or name
- support sort selector in FileManager
- track `added` date for projects in metadata
- return project `added` field from backend

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687516bf21a08321a72e5c4bff0e6f73