### PR TITLE
Fix layout overflow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -33,7 +33,7 @@ body {
   display: flex;
   flex-direction: column;
   padding: calc(var(--space-4) * 2.5);
-  overflow-y: auto;
+  overflow: hidden;
   position: relative;
 }
 

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-height: calc(100vh - 80px);
+  min-height: 0;
   position: relative;
   background-color: #1e1e1e;
   color: #e0e0e0;
@@ -26,13 +26,15 @@
 
 .script-viewer-content {
   flex-grow: 1;
-  overflow-y: auto;
+  overflow: hidden;
   padding: 2.5rem;
   background-color: #1e1e1e;
   line-height: 1.6;
   font-size: 16px;
   max-width: 800px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
 }
 
 
@@ -70,10 +72,10 @@
   flex-grow: 1;
   overflow-y: auto;
   padding: 0;
-  background-color: #161616;
+  background-color: #1e1e1e;
   font-family: sans-serif;
   width: 100%;
-  min-height: 100%;
+  min-height: 0;
 }
 
 .load-placeholder {


### PR DESCRIPTION
## Summary
- prevent right panel from scrolling
- remove min-height on script viewer and let content scroll only in editor
- set editor background to match main layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687518156e048321885f8f2dfba3d2a7