### PR TITLE
Add per-project sorting dropdown

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -99,6 +99,20 @@ body {
   overflow: hidden;
 }
 
+.sort-select {
+  background: none;
+  border: none;
+  color: #e0e0e0;
+  padding: 2px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sort-select option {
+  background-color: #333;
+  color: #e0e0e0;
+}
+
 .file-manager-header button:hover {
   background-color: var(--accent-color);
 }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -80,6 +80,7 @@ const FileManager = forwardRef(function FileManager({
   const [collapsed, setCollapsed] = useState({});
   const [tooltipScript, setTooltipScript] = useState(null);
   const tooltipTimerRef = useRef(null);
+  const [scriptSort, setScriptSort] = useState({});
 
 
   useEffect(() => {
@@ -295,71 +296,94 @@ const FileManager = forwardRef(function FileManager({
                     >
                       <TrashIcon />
                     </button>
+                    <select
+                      className="sort-select"
+                      value={scriptSort[project.name] || 'date'}
+                      onChange={(e) =>
+                        setScriptSort((prev) => ({
+                          ...prev,
+                          [project.name]: e.target.value,
+                        }))
+                      }
+                    >
+                      <option value="date">Date Added</option>
+                      <option value="name">Name</option>
+                    </select>
                   </div>
                 </>
               )}
             </div>
             <ul>
-              {project.scripts.map((script) => {
-                const isPrompting =
-                  loadedProject === project.name && loadedScript === script;
-                const isLoaded =
-                  currentProject === project.name && currentScript === script;
-                const isRenaming =
-                  renamingScript &&
-                  renamingScript.projectName === project.name &&
-                  renamingScript.scriptName === script;
-                return (
-                  <li
-                    key={script}
-                    className={`script-item${
-                      isPrompting ? ' prompting' : ''
-                    }${isLoaded ? ' loaded' : ''}`}
-                  >
-                    {isRenaming ? (
-                      <>
-                        <input
-                          type="text"
-                          value={renameValue}
-                          onChange={(e) => setRenameValue(e.target.value)}
-                        />
-                        <button onClick={() => confirmRenameScript(project.name, script)}>Save</button>
-                        <button onClick={cancelRename}>Cancel</button>
-                      </>
-                    ) : (
-                      <>
-                        <button
-                          className="script-button"
-                          onClick={() => onScriptSelect(project.name, script)}
-                          onMouseEnter={() => handleScriptMouseEnter(script)}
-                          onMouseLeave={handleScriptMouseLeave}
-                        >
-                          {script.replace(/\.[^/.]+$/, '')}
-                          {tooltipScript === script && (
-                            <span className="script-tooltip">{script}</span>
-                          )}
-                        </button>
-                        <div className="script-actions">
+              {(() => {
+                const sortKey = scriptSort[project.name] || 'date';
+                const scripts = [...project.scripts].sort((a, b) => {
+                  if (sortKey === 'name') {
+                    return a.name.localeCompare(b.name);
+                  }
+                  return (b.added || 0) - (a.added || 0);
+                });
+                return scripts.map((scriptObj) => {
+                  const script = scriptObj.name;
+                  const isPrompting =
+                    loadedProject === project.name && loadedScript === script;
+                  const isLoaded =
+                    currentProject === project.name && currentScript === script;
+                  const isRenaming =
+                    renamingScript &&
+                    renamingScript.projectName === project.name &&
+                    renamingScript.scriptName === script;
+                  return (
+                    <li
+                      key={script}
+                      className={`script-item${
+                        isPrompting ? ' prompting' : ''
+                      }${isLoaded ? ' loaded' : ''}`}
+                    >
+                      {isRenaming ? (
+                        <>
+                          <input
+                            type="text"
+                            value={renameValue}
+                            onChange={(e) => setRenameValue(e.target.value)}
+                          />
+                          <button onClick={() => confirmRenameScript(project.name, script)}>Save</button>
+                          <button onClick={cancelRename}>Cancel</button>
+                        </>
+                      ) : (
+                        <>
                           <button
-                            className="icon-button"
-                            onClick={() => startRenameScript(project.name, script)}
-                            aria-label="Rename"
+                            className="script-button"
+                            onClick={() => onScriptSelect(project.name, script)}
+                            onMouseEnter={() => handleScriptMouseEnter(script)}
+                            onMouseLeave={handleScriptMouseLeave}
                           >
-                            <PencilIcon />
+                            {script.replace(/\.[^/.]+$/, '')}
+                            {tooltipScript === script && (
+                              <span className="script-tooltip">{script}</span>
+                            )}
                           </button>
-                          <button
-                            className="icon-button"
-                            onClick={() => handleDeleteScript(project.name, script)}
-                            aria-label="Delete"
-                          >
-                            <TrashIcon />
-                          </button>
-                        </div>
-                      </>
-                    )}
-                  </li>
-                );
-              })}
+                          <div className="script-actions">
+                            <button
+                              className="icon-button"
+                              onClick={() => startRenameScript(project.name, script)}
+                              aria-label="Rename"
+                            >
+                              <PencilIcon />
+                            </button>
+                            <button
+                              className="icon-button"
+                              onClick={() => handleDeleteScript(project.name, script)}
+                              aria-label="Delete"
+                            >
+                              <TrashIcon />
+                            </button>
+                          </div>
+                        </>
+                      )}
+                    </li>
+                  );
+                });
+              })()}
             </ul>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- return script creation dates from `get-all-projects-with-scripts`
- show a small sort dropdown with each project action bar
- allow scripts within each project to be sorted by date or name
- tweak `.sort-select` styling for compact look

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687516bf21a08321a72e5c4bff0e6f73