### PR TITLE
Fix script viewer cleanup when selection cleared

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -32,6 +32,7 @@ function ScriptViewer({
         });
     } else {
       setScriptHtml(null);
+      window.electronAPI.sendUpdatedScript('');
     }
     return () => {
       cancelled = true;
@@ -119,11 +120,11 @@ function ScriptViewer({
     const hadSelection =
       prevSelection.current.projectName && prevSelection.current.scriptName;
     const hasSelection = projectName && scriptName;
-    if (hadSelection && !hasSelection && scriptHtml !== null) {
+    if (hadSelection && !hasSelection) {
       handleClose();
     }
     prevSelection.current = { projectName, scriptName };
-  }, [projectName, scriptName, scriptHtml, handleClose]);
+  }, [projectName, scriptName, handleClose]);
 
   const showLogo = scriptHtml === null;
 


### PR DESCRIPTION
## Summary
- ensure prompter is cleared when no script is selected
- close viewer whenever selection becomes null without depending on script content

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687529b5888c8321ad9562da1c4a64f9