### PR TITLE
Update send button behavior

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -379,3 +379,9 @@ body {
   color: #1e1e1e;
 }
 
+.send-button:disabled {
+  background-color: #666;
+  color: #999;
+  cursor: not-allowed;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,7 @@ function App() {
           <button
             className="send-button"
             onClick={() => sendCallbackRef.current && sendCallbackRef.current()}
+            disabled={!sendCallbackRef.current}
           >
             Let&apos;s Go!
           </button>

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -84,10 +84,8 @@ function ScriptViewer({
   }, [scriptHtml, projectName, scriptName, onPrompterOpen]);
 
   useEffect(() => {
-    if (onSend) {
-      onSend(() => handleSend());
-    }
-  }, [onSend, handleSend]);
+    onSend?.(scriptHtml ? () => handleSend() : null);
+  }, [onSend, handleSend, scriptHtml]);
 
   useEffect(() => {
     const cleanup = window.electronAPI.onPrompterClosed(() => {


### PR DESCRIPTION
## Summary
- pass `null` to `onSend` when there's no loaded script
- disable the send button when there is no send callback
- style disabled send button

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687529b730408321a4b6269af37c4f1a