### PR TITLE
Ensure ScriptViewer cleanup on unmount

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -97,6 +97,9 @@ function ScriptViewer({
     };
   }, [onPrompterClose]);
 
+  // Clean up when the component unmounts
+  useEffect(() => () => handleClose(), [handleClose]);
+
   const handleClose = useCallback(() => {
     if (saveTimeout.current) {
       clearTimeout(saveTimeout.current);


### PR DESCRIPTION
## Summary
- add cleanup `useEffect` so closing the route triggers `handleClose`
- keep prompter in sync by clearing scriptHtml and sending an empty update when closing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68752decc0e883218718efefdcc2cbb9