### PR TITLE
Add cleanup for prompter IPC events

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -5,10 +5,16 @@ console.log('[PRELOAD] Preload script loaded ✅');
 contextBridge.exposeInMainWorld('electronAPI', {
   // Prompter controls
   openPrompter: (html) => ipcRenderer.send('open-prompter', html),
-  onScriptLoaded: (callback) =>
-    ipcRenderer.on('load-script', (_, data) => callback(data)),
-  onScriptUpdated: (callback) =>
-    ipcRenderer.on('update-script', (_, data) => callback(data)),
+  onScriptLoaded: (callback) => {
+    const handler = (_, data) => callback(data)
+    ipcRenderer.on('load-script', handler)
+    return () => ipcRenderer.removeListener('load-script', handler)
+  },
+  onScriptUpdated: (callback) => {
+    const handler = (_, data) => callback(data)
+    ipcRenderer.on('update-script', handler)
+    return () => ipcRenderer.removeListener('update-script', handler)
+  },
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
   getCurrentScript: () => ipcRenderer.invoke('get-current-script'),
   NEW_PROJECT_SENTINEL: '__NEW_PROJECT__',

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -86,14 +86,17 @@ function Prompter() {
       setContent(html)
     }
 
-    window.electronAPI.onScriptLoaded(handleLoaded)
-    window.electronAPI.onScriptUpdated(handleUpdated)
+    const cleanupLoaded = window.electronAPI.onScriptLoaded(handleLoaded)
+    const cleanupUpdated = window.electronAPI.onScriptUpdated(handleUpdated)
     window.electronAPI.getCurrentScript().then((html) => {
       if (html) setContent(html)
       ready = true
     })
 
-    return () => {}
+    return () => {
+      cleanupLoaded?.()
+      cleanupUpdated?.()
+    }
   }, [])
 
 


### PR DESCRIPTION
## Summary
- remove `load-script` and `update-script` listeners from `preload.cjs`
- clean up those listeners in `Prompter.jsx`

## Testing
- `npm run lint`
- `npm run electron-dev` *(fails: running Electron without an X server)*

------
https://chatgpt.com/codex/tasks/task_e_68752decb79083219e068a23257202cf