### PR TITLE
Fix script viewer placeholder logic

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -124,7 +124,7 @@ function ScriptViewer({
     prevSelection.current = { projectName, scriptName };
   }, [projectName, scriptName, handleClose]);
 
-  const showLogo = scriptHtml === null;
+  const showLogo = !scriptName || scriptHtml === null;
 
   return (
     <div className="script-viewer">


### PR DESCRIPTION
## Summary
- show placeholder whenever no script is selected or the content isn't loaded

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68752dec76388321aadb1cf7139d7e43