### PR TITLE
Ensure prompter cleanup removes listeners

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -5,10 +5,16 @@ console.log('[PRELOAD] Preload script loaded ✅');
 contextBridge.exposeInMainWorld('electronAPI', {
   // Prompter controls
   openPrompter: (html) => ipcRenderer.send('open-prompter', html),
-  onScriptLoaded: (callback) =>
-    ipcRenderer.on('load-script', (_, data) => callback(data)),
-  onScriptUpdated: (callback) =>
-    ipcRenderer.on('update-script', (_, data) => callback(data)),
+  onScriptLoaded: (callback) => {
+    const handler = (_, data) => callback(data)
+    ipcRenderer.on('load-script', handler)
+    return () => ipcRenderer.removeListener('load-script', handler)
+  },
+  onScriptUpdated: (callback) => {
+    const handler = (_, data) => callback(data)
+    ipcRenderer.on('update-script', handler)
+    return () => ipcRenderer.removeListener('update-script', handler)
+  },
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
   getCurrentScript: () => ipcRenderer.invoke('get-current-script'),
   NEW_PROJECT_SENTINEL: '__NEW_PROJECT__',

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -86,14 +86,18 @@ function Prompter() {
       setContent(html)
     }
 
-    window.electronAPI.onScriptLoaded(handleLoaded)
-    window.electronAPI.onScriptUpdated(handleUpdated)
+    const cleanupLoaded = window.electronAPI.onScriptLoaded(handleLoaded)
+    const cleanupUpdated = window.electronAPI.onScriptUpdated(handleUpdated)
     window.electronAPI.getCurrentScript().then((html) => {
       if (html) setContent(html)
       ready = true
     })
 
-    return () => {}
+    return () => {
+      cleanupLoaded?.()
+      cleanupUpdated?.()
+      setContent('')
+    }
   }, [])
 
 


### PR DESCRIPTION
## Summary
- add cleanup returns for `onScriptLoaded` and `onScriptUpdated`
- clear listeners and reset content when `Prompter` unmounts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68752dec030083219cf61a470e44908d