### PR TITLE
Fix missing closing brace in CSS

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -83,6 +83,7 @@
 
 .script-content::-webkit-scrollbar {
   display: none; /* Chrome, Safari and Opera */
+}
 
 .load-placeholder {
   flex-grow: 1;


### PR DESCRIPTION
## Summary
- close the `.script-content::-webkit-scrollbar` rule in `ScriptViewer.css`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68753215f8988321bcd893ddb17c9b98