### PR TITLE
Define handleClose before usage

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -97,9 +97,6 @@ function ScriptViewer({
     };
   }, [onPrompterClose]);
 
-  // Clean up when the component unmounts
-  useEffect(() => () => handleClose(), [handleClose]);
-
   const handleClose = useCallback(() => {
     if (saveTimeout.current) {
       clearTimeout(saveTimeout.current);
@@ -113,6 +110,9 @@ function ScriptViewer({
     window.electronAPI.sendUpdatedScript('');
     onCloseViewer?.();
   }, [projectName, scriptName, scriptHtml, onPrompterClose, onCloseViewer]);
+
+  // Clean up when the component unmounts
+  useEffect(() => () => handleClose(), [handleClose]);
 
   // Ensure the viewer properly cleans up when no script is selected
   const prevSelection = useRef({ projectName: null, scriptName: null });


### PR DESCRIPTION
## Summary
- move `handleClose` earlier in `ScriptViewer.jsx` to prevent reference errors

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68753216f7788321baff3648ae137c4e