### PR TITLE
Define handleClose before usage

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -14,17 +14,20 @@ function ScriptViewer({
   onSend,
 }) {
   const [scriptHtml, setScriptHtml] = useState(null);
+  const [loaded, setLoaded] = useState(false);
   const contentRef = useRef(null);
   const saveTimeout = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
     if (projectName && scriptName) {
+      setLoaded(false);
       window.electronAPI
         .loadScript(projectName, scriptName)
         .then((html) => {
           if (!cancelled) {
             setScriptHtml(html);
+            setLoaded(true);
           }
         })
         .catch((err) => {
@@ -32,6 +35,7 @@ function ScriptViewer({
         });
     } else {
       setScriptHtml(null);
+      setLoaded(false);
       window.electronAPI.sendUpdatedScript('');
     }
     return () => {
@@ -78,15 +82,13 @@ function ScriptViewer({
   };
 
   const handleSend = useCallback(() => {
-    if (scriptHtml) {
-      window.electronAPI.openPrompter(scriptHtml);
-      onPrompterOpen?.(projectName, scriptName);
-    }
+    window.electronAPI.openPrompter(scriptHtml || '');
+    onPrompterOpen?.(projectName, scriptName);
   }, [scriptHtml, projectName, scriptName, onPrompterOpen]);
 
   useEffect(() => {
-    onSend?.(scriptHtml ? () => handleSend() : null);
-  }, [onSend, handleSend, scriptHtml]);
+    onSend?.(loaded ? () => handleSend() : null);
+  }, [onSend, handleSend, loaded]);
 
   useEffect(() => {
     const cleanup = window.electronAPI.onPrompterClosed(() => {
@@ -97,9 +99,6 @@ function ScriptViewer({
     };
   }, [onPrompterClose]);
 
-  // Clean up when the component unmounts
-  useEffect(() => () => handleClose(), [handleClose]);
-
   const handleClose = useCallback(() => {
     if (saveTimeout.current) {
       clearTimeout(saveTimeout.current);
@@ -109,10 +108,16 @@ function ScriptViewer({
       window.electronAPI.saveScript(projectName, scriptName, scriptHtml);
     }
     setScriptHtml(null);
+    setLoaded(false);
     onPrompterClose?.();
     window.electronAPI.sendUpdatedScript('');
     onCloseViewer?.();
   }, [projectName, scriptName, scriptHtml, onPrompterClose, onCloseViewer]);
+
+  // Clean up when the component unmounts
+  // intentionally omit handleClose from deps so this runs only once
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => () => handleClose(), []);
 
   // Ensure the viewer properly cleans up when no script is selected
   const prevSelection = useRef({ projectName: null, scriptName: null });
@@ -125,9 +130,10 @@ function ScriptViewer({
       handleClose();
     }
     prevSelection.current = { projectName, scriptName };
-  }, [projectName, scriptName, handleClose]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectName, scriptName]);
 
-  const showLogo = !scriptName || scriptHtml === null;
+  const showLogo = !loaded;
 
   return (
     <div className="script-viewer">
@@ -136,7 +142,7 @@ function ScriptViewer({
           <h2 className="header-title">Script Viewer</h2>
         </div>
       </div>
-      {scriptName && (
+      {loaded && scriptName && (
         <div className="header-buttons">
           <div className="script-name">
             {scriptName.replace(/\.[^/.]+$/, '')}


### PR DESCRIPTION
## Summary
- move `handleClose` earlier in `ScriptViewer.jsx` to prevent reference errors
- track loaded state for script viewer and set "Let's Go" button based on it
- prevent effects from re-running by omitting `handleClose` in dependency arrays

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68753216f7788321baff3648ae137c4e