### PR TITLE
Add confirmation dialogs for deletions

### DIFF
--- a/src/ConfirmModal.css
+++ b/src/ConfirmModal.css
@@ -1,0 +1,41 @@
+.confirm-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.confirm-modal {
+  background: #222;
+  padding: calc(var(--space-4) * 2);
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+  max-width: 300px;
+  text-align: center;
+}
+
+.confirm-modal p {
+  margin: 0 0 var(--space-3) 0;
+}
+
+.confirm-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.confirm-modal button {
+  padding: var(--space-2) var(--space-4);
+}
+
+.delete-button {
+  background-color: #bb4444;
+  color: #fff;
+}
+
+.delete-button:hover {
+  background-color: #dd5555;
+}

--- a/src/ConfirmModal.jsx
+++ b/src/ConfirmModal.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './ConfirmModal.css';
+
+function ConfirmModal({ message, onConfirm, onCancel }) {
+  return (
+    <div className="confirm-modal-overlay">
+      <div className="confirm-modal">
+        <p>{message}</p>
+        <div className="confirm-buttons">
+          <button onClick={onCancel}>Cancel</button>
+          <button className="delete-button" onClick={onConfirm}>Delete</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmModal;


### PR DESCRIPTION
## Summary
- add `ConfirmModal` component with simple styling
- update `FileManager` to show confirmation before deleting projects or scripts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68754e6a85dc8321b995a1940dafc6e8