### PR TITLE
Move sorting dropdown into project headers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,12 +100,13 @@ body {
   overflow: hidden;
 }
 
+
 .sort-select {
-  padding: var(--space-2) var(--space-4);
-  background-color: #333;
-  color: #e0e0e0;
+  background: none;
   border: none;
-  border-radius: 6px;
+  color: #e0e0e0;
+  padding: 2px;
+  border-radius: 4px;
   cursor: pointer;
 }
 

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -256,14 +256,6 @@ const FileManager = forwardRef(function FileManager({
         </div>
       </div>
       <div className="header-buttons">
-        <select
-          className="sort-select"
-          value={sortBy}
-          onChange={(e) => setSortBy(e.target.value)}
-        >
-          <option value="date">Date Added</option>
-          <option value="name">Name</option>
-        </select>
         <button onClick={handleNewScript}>+ New Script</button>
         <button onClick={() => setShowNewProjectInput(!showNewProjectInput)}>
           + New Project
@@ -332,6 +324,14 @@ const FileManager = forwardRef(function FileManager({
                     >
                       <TrashIcon />
                     </button>
+                    <select
+                      className="sort-select"
+                      value={sortBy}
+                      onChange={(e) => setSortBy(e.target.value)}
+                    >
+                      <option value="date">Date Added</option>
+                      <option value="name">Name</option>
+                    </select>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## Summary
- move project sorting dropdown next to each project's action buttons
- style dropdown to match project action buttons

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875568fe75c8321bc8d43fc9524b024