### PR TITLE
Set minimum window size to 1200x800

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -131,8 +131,10 @@ function updateProjectMetadata(projectName) {
 
 function createMainWindow() {
   mainWindow = new BrowserWindow({
-    width: 900,
-    height: 700,
+    width: 1200,
+    height: 800,
+    minWidth: 1200,
+    minHeight: 800,
     webPreferences: {
       preload: path.resolve(__dirname, 'preload.cjs'),
       contextIsolation: true,
@@ -185,6 +187,8 @@ async function createPrompterWindow() {
   const baseOptions = {
     width: 1200,
     height: 800,
+    minWidth: 1200,
+    minHeight: 800,
     show: false,
     webPreferences: {
       preload: path.resolve(__dirname, 'preload.cjs'),

--- a/src/index.css
+++ b/src/index.css
@@ -39,8 +39,8 @@ body {
   margin: 0;
   display: flex;
   place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
+  min-width: 1200px;
+  min-height: 800px;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- enforce a min window size of 1200x800 for main and prompter windows
- update CSS body rules so the layout matches the minimum app size

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6875570795848321a9fe3417902701a3