### PR TITLE
Move sorting dropdown into project headers

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -334,7 +334,14 @@ app.whenReady().then(async () => {
 
       const result = projects.map((projectName) => {
         const scriptsDir = path.join(baseDir, projectName);
-        const scripts = fs.readdirSync(scriptsDir).filter((file) => file.endsWith('.docx'));
+        const scripts = fs
+          .readdirSync(scriptsDir)
+          .filter((file) => file.endsWith('.docx'))
+          .map((file) => {
+            const stats = fs.statSync(path.join(scriptsDir, file));
+            const added = stats.birthtimeMs || stats.ctimeMs || stats.mtimeMs;
+            return { name: file, added };
+          });
         const meta = metadata.projects.find((p) => p.name === projectName);
         const added = meta?.added || 0;
         return { name: projectName, scripts, added };

--- a/src/App.css
+++ b/src/App.css
@@ -100,12 +100,13 @@ body {
   overflow: hidden;
 }
 
+
 .sort-select {
-  padding: var(--space-2) var(--space-4);
-  background-color: #333;
-  color: #e0e0e0;
+  background: none;
   border: none;
-  border-radius: 6px;
+  color: #e0e0e0;
+  padding: 2px;
+  border-radius: 4px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- move project sorting dropdown next to each project's action buttons
- style dropdown to match project action buttons
- allow sorting scripts by name or date added

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875568fe75c8321bc8d43fc9524b024