### PR TITLE
Add Quick Scripts creation

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -485,11 +485,8 @@ app.whenReady().then(async () => {
       }
       finalName = `${candidate}.docx`;
       const dest = path.join(base, finalName);
-      const template = path.join(
-        __dirname,
-              'resources',
-      );
-      fs.copyFileSync(template, dest);
+      const buffer = await htmlToDocx('');
+      fs.writeFileSync(dest, buffer);
       return { success: true, scriptName: finalName };
     } catch (err) {
       error('Failed to create new script:', err);

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -139,11 +139,7 @@ const FileManager = forwardRef(function FileManager({
   };
 
   const handleNewScript = async () => {
-    let projectName = projects[0]?.name || 'Default';
-    if (!projects.length) {
-      await window.electronAPI.createNewProject(projectName);
-      await loadProjects();
-    }
+    const projectName = 'Quick Scripts';
     const result = await window.electronAPI.createNewScript(projectName, 'New Script');
     if (result && result.success) {
       await loadProjects();


### PR DESCRIPTION
## Summary
- create new scripts inside **Quick Scripts** project
- generate a blank docx instead of copying a template

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68755773692883219bc2d56158872396