### PR TITLE
Fix create new script TypeError

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -492,7 +492,7 @@ app.whenReady().then(async () => {
       }
       finalName = `${candidate}.docx`;
       const dest = path.join(base, finalName);
-      const buffer = await htmlToDocx('');
+      const buffer = await htmlToDocx('<p></p>', null, {});
       fs.writeFileSync(dest, buffer);
       return { success: true, scriptName: finalName };
     } catch (err) {


### PR DESCRIPTION
## Summary
- fix htmlToDocx invocation when creating a new script

## Testing
- `npm run lint`
- `node -e "const htmlToDocx=require('./node_modules/html-to-docx'); htmlToDocx('<p></p>', null, {}).then(buf=>console.log('buf length', buf.length));"`


------
https://chatgpt.com/codex/tasks/task_e_687662f787708321b46ec7a5e3c3d863