### PR TITLE
Remove unused NEW_PROJECT_SENTINEL constant

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -16,7 +16,6 @@ const pendingLogs = [];
 let viteProcess;
 let isAlwaysOnTop = false;
 let currentScriptHtml = '';
-const NEW_PROJECT_SENTINEL = '__NEW_PROJECT__';
 
 function sendLog(msg) {
   if (devConsoleWindow && !devConsoleWindow.isDestroyed()) {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -17,7 +17,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   sendUpdatedScript: (html) => ipcRenderer.send('update-script', html),
   getCurrentScript: () => ipcRenderer.invoke('get-current-script'),
-  NEW_PROJECT_SENTINEL: '__NEW_PROJECT__',
 
   // Project management
   selectProjectFolder: () => ipcRenderer.invoke('select-project-folder'),


### PR DESCRIPTION
## Summary
- delete `NEW_PROJECT_SENTINEL` from preload and main processes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687aa2baecd083218e3cd21a206a328f