### PR TITLE
Fix editable view for new scripts

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -165,7 +165,8 @@ useEffect(() => {
             <div
               ref={contentRef}
               className="script-content"
-              contentEditable
+              contentEditable={true}
+              suppressContentEditableWarning={true}
               onBlur={handleBlur}
               onInput={handleInput}
             />


### PR DESCRIPTION
## Summary
- ensure the script editor sets `contentEditable` explicitly
- suppress React's editable div warning

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687aa45531b08321bbda64eddaf81268