### PR TITLE
Add drop target highlight for FileManager drag

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -272,10 +272,25 @@ body {
   color: #1e1e1e;
 }
   
+
+.script-item {
+  position: relative;
+}
+
 .script-item.loaded.prompting .script-button {
   background-color: var(--accent-color);
   color: #1e1e1e;
   border-color: var(--accent-color);
+}
+
+.script-item.drop-target::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background-color: var(--accent-color);
 }
 
 .script-actions {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -84,6 +84,7 @@ const FileManager = forwardRef(function FileManager({
   const [sortBy, setSortBy] = useState('');
   const [confirmState, setConfirmState] = useState(null);
   const [dragInfo, setDragInfo] = useState(null);
+  const [hoverIndex, setHoverIndex] = useState(null);
 
 
   useEffect(() => {
@@ -241,6 +242,14 @@ const FileManager = forwardRef(function FileManager({
     e.preventDefault();
   };
 
+  const handleDragEnter = (index) => {
+    setHoverIndex(index);
+  };
+
+  const handleDragLeave = (index) => {
+    setHoverIndex((prev) => (prev === index ? null : prev));
+  };
+
   const handleDrop = async (e, projectName, index) => {
     e.preventDefault();
     if (!dragInfo || dragInfo.projectName !== projectName) return;
@@ -258,6 +267,7 @@ const FileManager = forwardRef(function FileManager({
       }),
     );
     setDragInfo(null);
+    setHoverIndex(null);
     if (newOrder) {
       await window.electronAPI.reorderScripts(projectName, newOrder);
     }
@@ -384,10 +394,17 @@ const FileManager = forwardRef(function FileManager({
                       onDragStart={() => handleDragStart(project.name, index)}
                       onDragOver={handleDragOver}
                       onDrop={(e) => handleDrop(e, project.name, index)}
-                      onDragEnd={() => setDragInfo(null)}
+                      onDragEnter={() => handleDragEnter(index)}
+                      onDragLeave={() => handleDragLeave(index)}
+                      onDragEnd={() => {
+                        setDragInfo(null);
+                        setHoverIndex(null);
+                      }}
                       className={`script-item${
                         isPrompting ? ' prompting' : ''
-                      }${isLoaded ? ' loaded' : ''}`}
+                      }${isLoaded ? ' loaded' : ''}${
+                        hoverIndex === index ? ' drop-target' : ''
+                      }`}
                     >
                       {isRenaming ? (
                         <>


### PR DESCRIPTION
## Summary
- track drag hover index in FileManager
- highlight list row when hovered during drag
- show drop target line with CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687aa5cdcb608321913adebb882f506b