### PR TITLE
Adjust script viewer placeholder layout

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -86,12 +86,14 @@
 }
 
 .load-placeholder {
-  flex-grow: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
   text-align: center;
-  font-size: 1.2rem;
+  pointer-events: none;
+  font-size: clamp(1rem, 2.5vw, 1.5rem);
   color: #aaa;
 }
 

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -161,12 +161,13 @@ useEffect(() => {
           </button>
         </div>
       )}
+      {showLogo && (
+        <div className="load-placeholder">
+          Welcome to LeaderPrompt. Please load or create a script.
+        </div>
+      )}
       <div className="script-viewer-content">
-        {showLogo ? (
-          <div className="load-placeholder">
-            Welcome to LeaderPrompt. Please load or create a script.
-          </div>
-        ) : (
+        {!showLogo && (
           <>
             <div
               ref={contentRef}


### PR DESCRIPTION
## Summary
- reposition `.load-placeholder` to cover entire viewer
- style placeholder for centered appearance
- only render script content once loaded

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687aab46c9548321b6b58569b4591fb2