### PR TITLE
Move editor close button

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -53,6 +53,22 @@
   color: var(--accent-color);
 }
 
+.editor-close-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem;
+  background: none;
+  border: none;
+  color: #aaa;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.editor-close-button:hover {
+  color: var(--accent-color);
+}
+
 .script-viewer .header-buttons {
   display: flex;
   align-items: center;

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -142,6 +142,15 @@ useEffect(() => {
 
   return (
     <div className="script-viewer">
+      {loaded && scriptName && (
+        <button
+          className="editor-close-button"
+          onClick={handleClose}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      )}
       <div className="viewer-header">
         <div className="header-left">
           <h2 className="header-title">Script Viewer</h2>
@@ -152,13 +161,6 @@ useEffect(() => {
           <div className="script-name">
             {scriptName.replace(/\.[^/.]+$/, '')}
           </div>
-          <button
-            className="close-button"
-            onClick={handleClose}
-            aria-label="Close"
-          >
-            ×
-          </button>
         </div>
       )}
       <div className="script-viewer-content">


### PR DESCRIPTION
## Summary
- drop close button from header
- add close button overlaying the ScriptViewer
- style new `.editor-close-button`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687aab4581588321a89f08eab8995593