### PR TITLE
Fix asset paths for packaged build

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -166,7 +166,7 @@ function createDevConsoleWindow() {
   })
 
   const url = app.isPackaged
-    ? pathToFile('index.html', '#/dev-console')
+    ? pathToFile('dist/index.html', '#/dev-console')
     : 'http://localhost:5173/#/dev-console'
 
   devConsoleWindow.loadURL(url)
@@ -200,7 +200,7 @@ async function createPrompterWindow() {
   };
 
   const url = app.isPackaged
-    ? pathToFile('index.html', '#/prompter')
+    ? pathToFile('dist/index.html', '#/prompter')
     : 'http://localhost:5173/#/prompter';
 
   if (!prompterWindow || prompterWindow.isDestroyed()) {

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/logos/LP_white.png" />
+    <link rel="icon" type="image/png" href="./logos/LP_white.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LeaderPrompt</title>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="./src/main.jsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'Metropolis-Bold';
-  src: url('/fonts/Metropolis-Bold.otf') format('opentype');
+  src: url('../fonts/Metropolis-Bold.otf') format('opentype');
   font-weight: 700;
   font-style: normal;
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- make asset references relative
- load `dist/index.html` in all Electron windows when packaged
- use relative path for font in CSS
- set Vite base path for relative builds

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e3e521b00832199dd87f20e3dc667