### PR TITLE
Move placeholder

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -401,3 +401,15 @@ body {
   cursor: not-allowed;
 }
 
+.load-placeholder {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  text-align: center;
+  pointer-events: none;
+  font-size: clamp(1rem, 2.5vw, 1.5rem);
+  color: #aaa;
+}
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ function App() {
   const [loadedProject, setLoadedProject] = useState(null);
   const fileManagerRef = useRef(null);
   const [sendCallback, setSendCallback] = useState(null);
+  const [viewerLoaded, setViewerLoaded] = useState(false);
 
   const handleScriptSelect = (projectName, scriptName) => {
     setSelectedProject(projectName);
@@ -46,6 +47,11 @@ function App() {
         />
       </div>
       <div className="right-panel">
+        {!viewerLoaded && (
+          <div className="load-placeholder">
+            Welcome to LeaderPrompt. Please load or create a script.
+          </div>
+        )}
         <ScriptViewer
           projectName={selectedProject}
           scriptName={selectedScript}
@@ -54,6 +60,7 @@ function App() {
           onPrompterOpen={handlePrompterOpen}
           onPrompterClose={handlePrompterClose}
           onCloseViewer={handleViewerClose}
+          onLoadedChange={setViewerLoaded}
           onSend={(cb) => {
             setSendCallback(() => cb);
           }}

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -101,17 +101,6 @@
   display: none; /* Chrome, Safari and Opera */
 }
 
-.load-placeholder {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: 100%;
-  text-align: center;
-  pointer-events: none;
-  font-size: clamp(1rem, 2.5vw, 1.5rem);
-  color: #aaa;
-}
 
 .link-button {
   background: none;

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -10,6 +10,7 @@ function ScriptViewer({
   onPrompterClose,
   onCloseViewer,
   onSend,
+  onLoadedChange,
 }) {
   const [scriptHtml, setScriptHtml] = useState(null);
   const [loaded, setLoaded] = useState(false);
@@ -124,6 +125,10 @@ useEffect(() => {
 
   useEffect(() => () => handleClose(), []);
 
+  useEffect(() => {
+    onLoadedChange?.(loaded);
+  }, [loaded, onLoadedChange]);
+
   // Ensure the viewer properly cleans up when no script is selected
   const prevSelection = useRef({ projectName: null, scriptName: null });
 
@@ -138,7 +143,7 @@ useEffect(() => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectName, scriptName]);
 
-  const showLogo = !loaded;
+  const showContent = loaded;
 
   return (
     <div className="script-viewer">
@@ -163,13 +168,8 @@ useEffect(() => {
           </div>
         </div>
       )}
-      {showLogo && (
-        <div className="load-placeholder">
-          Welcome to LeaderPrompt. Please load or create a script.
-        </div>
-      )}
       <div className="script-viewer-content">
-        {!showLogo && (
+        {showContent && (
           <>
             <div
               ref={contentRef}


### PR DESCRIPTION
## Summary
- lift script viewer loaded state to `App` via `onLoadedChange`
- show load placeholder from `App` instead of inside `ScriptViewer`
- relocate placeholder styles to `App.css`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687aad2c1d8c8321a253939189b1abd2