### PR TITLE
Move close button and fix viewer sizing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -374,9 +374,11 @@ body {
   position: sticky;
   bottom: var(--space-3);
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   padding-top: var(--space-3);
   background-color: #1e1e1e;
+  width: 100%;
+  gap: var(--space-2);
 }
 
 .send-button {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ function App() {
   const [loadedProject, setLoadedProject] = useState(null);
   const fileManagerRef = useRef(null);
   const [sendCallback, setSendCallback] = useState(null);
+  const [closeCallback, setCloseCallback] = useState(null);
   const [viewerLoaded, setViewerLoaded] = useState(false);
 
   const handleScriptSelect = (projectName, scriptName) => {
@@ -61,21 +62,34 @@ function App() {
           onPrompterClose={handlePrompterClose}
           onCloseViewer={handleViewerClose}
           onLoadedChange={setViewerLoaded}
+          onClose={(cb) => {
+            setCloseCallback(() => cb);
+          }}
           onSend={(cb) => {
             setSendCallback(() => cb);
           }}
         />
-        {sendCallback && (
-          <div className="send-button-container">
-            <button
-              className="send-button"
-              onClick={() => sendCallback && sendCallback()}
-              disabled={!sendCallback}
-            >
-              Let&apos;s Go!
-            </button>
-          </div>
-        )}
+          {(closeCallback || sendCallback) && (
+            <div className="send-button-container">
+              {closeCallback && (
+                <button
+                  className="send-button"
+                  onClick={() => closeCallback && closeCallback()}
+                >
+                  Close
+                </button>
+              )}
+              {sendCallback && (
+                <button
+                  className="send-button"
+                  onClick={() => sendCallback && sendCallback()}
+                  disabled={!sendCallback}
+                >
+                  Let&apos;s Go!
+                </button>
+              )}
+            </div>
+          )}
       </div>
       <img src={leaderLogo} alt="LeaderPrompt Logo" className="main-logo" />
     </div>

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -53,21 +53,6 @@
   color: var(--accent-color);
 }
 
-.editor-close-button {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  padding: 0.25rem;
-  background: none;
-  border: none;
-  color: #aaa;
-  cursor: pointer;
-  z-index: 10;
-}
-
-.editor-close-button:hover {
-  color: var(--accent-color);
-}
 
 .script-viewer .header-buttons {
   display: flex;
@@ -95,6 +80,9 @@
   font-family: sans-serif;
   width: 100%;
   min-height: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .script-content::-webkit-scrollbar {

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -11,6 +11,7 @@ function ScriptViewer({
   onCloseViewer,
   onSend,
   onLoadedChange,
+  onClose,
 }) {
   const [scriptHtml, setScriptHtml] = useState(null);
   const [loaded, setLoaded] = useState(false);
@@ -129,6 +130,10 @@ useEffect(() => {
     onLoadedChange?.(loaded);
   }, [loaded, onLoadedChange]);
 
+  useEffect(() => {
+    onClose?.(loaded && scriptName ? () => handleClose() : null);
+  }, [onClose, handleClose, loaded, scriptName]);
+
   // Ensure the viewer properly cleans up when no script is selected
   const prevSelection = useRef({ projectName: null, scriptName: null });
 
@@ -147,15 +152,6 @@ useEffect(() => {
 
   return (
     <div className="script-viewer">
-      {loaded && scriptName && (
-        <button
-          className="editor-close-button"
-          onClick={handleClose}
-          aria-label="Close"
-        >
-          ×
-        </button>
-      )}
       <div className="viewer-header">
         <div className="header-left">
           <h2 className="header-title">Script Viewer</h2>


### PR DESCRIPTION
## Summary
- provide close callback from `ScriptViewer`
- show a new close button next to **Let's Go!** at bottom of the editor
- update sticky footer layout for two buttons
- remove old close button style and ensure script content wraps

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e71f05a0083218b21070c9c407e52