### PR TITLE
Add toast notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ Edits made in the script editor are automatically written back to the underlying
 `html-to-docx` and saves it to the selected project/script location via the new
 `save-script` IPC handler exposed as
 `window.electronAPI.saveScript(projectName, scriptName, html)`.
+
+## Toast Notifications
+
+The interface uses [react-toastify](https://github.com/fkhadra/react-toastify) to
+provide non-intrusive alerts. The `ToastContainer` component is mounted in
+`main.jsx`, and components use `toast.success()` or `toast.error()` after
+operations like creating or deleting projects and saving scripts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "mammoth": "^1.9.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.3"
+        "react-router-dom": "^7.6.3",
+        "react-toastify": "^11.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -3349,6 +3350,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -6946,6 +6955,18 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-binary-file-arch": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "mammoth": "^1.9.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.3"
+    "react-router-dom": "^7.6.3",
+    "react-toastify": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -6,6 +6,7 @@ import {
   useRef,
 } from 'react';
 import ConfirmModal from './ConfirmModal.jsx';
+import { toast } from './toast';
 // The old project ActionMenu has been replaced with inline buttons
 
 function PencilIcon() {
@@ -112,11 +113,12 @@ const FileManager = forwardRef(function FileManager({
 
     const created = await window.electronAPI.createNewProject(newProjectName.trim());
     if (created) {
+      toast.success('Project created');
       setNewProjectName('');
       setShowNewProjectInput(false);
       loadProjects();
     } else {
-      console.error('Failed to create project');
+      toast.error('Failed to create project');
     }
   };
 
@@ -132,8 +134,11 @@ const FileManager = forwardRef(function FileManager({
     const projectName = 'Quick Scripts';
     const result = await window.electronAPI.createNewScript(projectName, 'New Script');
     if (result && result.success) {
+      toast.success('Script created');
       await loadProjects();
       onScriptSelect(projectName, result.scriptName);
+    } else {
+      toast.error('Failed to create script');
     }
   };
 
@@ -198,7 +203,11 @@ const FileManager = forwardRef(function FileManager({
       `Delete project "${projectName}"? This will remove all its scripts.`,
       async () => {
         const deleted = await window.electronAPI.deleteProject(projectName);
-        if (!deleted) console.error('Failed to delete project');
+        if (deleted) {
+          toast.success('Project deleted');
+        } else {
+          toast.error('Failed to delete project');
+        }
         await loadProjects();
       },
     );
@@ -209,7 +218,11 @@ const FileManager = forwardRef(function FileManager({
       `Delete script "${scriptName}" from "${projectName}"?`,
       async () => {
         const deleted = await window.electronAPI.deleteScript(projectName, scriptName);
-        if (!deleted) console.error('Failed to delete script');
+        if (deleted) {
+          toast.success('Script deleted');
+        } else {
+          toast.error('Failed to delete script');
+        }
         await loadProjects();
       },
     );

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -1,5 +1,6 @@
 import './ScriptViewer.css';
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { toast } from './toast';
 
 function ScriptViewer({
   projectName,
@@ -70,6 +71,7 @@ useEffect(() => {
       }
       saveTimeout.current = setTimeout(() => {
         window.electronAPI.saveScript(projectName, scriptName, html);
+        toast.success('Script saved');
         saveTimeout.current = null;
       }, 300);
     }
@@ -115,6 +117,7 @@ useEffect(() => {
     }
     if (projectName && scriptName && scriptHtml) {
       window.electronAPI.saveScript(projectName, scriptName, scriptHtml);
+      toast.success('Script saved');
     }
     setScriptHtml(null);
     setLoaded(false);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter, Routes, Route } from 'react-router-dom'
+import { ToastContainer } from './toast'
 import './index.css'
 
 import App from './App.jsx'
@@ -25,6 +26,7 @@ export function DevIcon() {
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HashRouter>
+      <ToastContainer />
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/prompter" element={<Prompter />} />

--- a/src/toast.js
+++ b/src/toast.js
@@ -1,0 +1,3 @@
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+export { toast, ToastContainer };


### PR DESCRIPTION
## Summary
- add `react-toastify` dependency
- expose toast utilities
- show toast notifications after project/script operations and on save
- mount `ToastContainer` in `main.jsx`
- document toast usage in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e7400a24c83219325cf877bad812e