### PR TITLE
Update create-new-script to copy template

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -519,8 +519,13 @@ app.whenReady().then(async () => {
       }
       finalName = `${candidate}.docx`;
       const dest = path.join(base, finalName);
-      const buffer = await htmlToDocx('<p></p>', null, {});
-      fs.writeFileSync(dest, buffer);
+      const templatePath = path.join(__dirname, '..', 'public', 'template.docx');
+      try {
+        await fs.promises.copyFile(templatePath, dest);
+      } catch (copyErr) {
+        const buffer = await htmlToDocx('<p></p>', null, {});
+        await fs.promises.writeFile(dest, buffer);
+      }
       return { success: true, scriptName: finalName };
     } catch (err) {
       error('Failed to create new script:', err);


### PR DESCRIPTION
## Summary
- ensure a unique docx filename with a Set of existing names
- copy a template file when creating a new script and fall back to a blank document if missing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e736751f08321a6eb790945a6418e