### PR TITLE
Fix placeholder layout and make UI responsive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -374,7 +374,8 @@ body {
   position: sticky;
   bottom: var(--space-3);
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   padding-top: var(--space-3);
   padding-left: clamp(1rem, 5vw, 2.5rem);
   padding-right: clamp(1rem, 5vw, 2.5rem);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,11 +48,6 @@ function App() {
         />
       </div>
       <div className="right-panel">
-        {!viewerLoaded && (
-          <div className="load-placeholder">
-            Welcome to LeaderPrompt. Please load or create a script.
-          </div>
-        )}
         <ScriptViewer
           projectName={selectedProject}
           scriptName={selectedScript}
@@ -91,6 +86,11 @@ function App() {
             </div>
           )}
       </div>
+      {!viewerLoaded && (
+        <div className="load-placeholder">
+          Welcome to LeaderPrompt. Please load or create a script.
+        </div>
+      )}
       <img src={leaderLogo} alt="LeaderPrompt Logo" className="main-logo" />
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -43,8 +43,8 @@ body {
   margin: 0;
   display: flex;
   place-items: center;
-  min-width: 1200px;
-  min-height: 800px;
+  width: 100vw;
+  height: 100vh;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- center the load placeholder relative to the main layout
- update send button container flex rules so buttons remain visible
- prevent body from forcing scroll bars

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e80e0cc488321bb36fb187da0b432