### PR TITLE
Refactor layout for flex column flow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,11 +32,10 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  height: 100%;
   padding: 2vw;
   overflow-y: auto;
   overflow-x: hidden;
-  position: relative;
 }
 
 .import-button {
@@ -365,15 +364,12 @@ body {
 
 .main-logo {
   width: 10vw;
-  position: absolute;
-  bottom: 2vh;
-  right: 2vw;
+  margin-top: auto;
+  align-self: flex-end;
 }
 
 /* Send button positioned at the bottom of the right panel */
 .send-button-container {
-  position: sticky;
-  bottom: 2vh;
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
@@ -381,6 +377,7 @@ body {
   background-color: #1e1e1e;
   width: 100%;
   gap: var(--space-2);
+  margin-top: auto;
 }
 
 .send-button {
@@ -406,15 +403,13 @@ body {
 }
 
 .load-placeholder {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   width: 100%;
   text-align: center;
-  pointer-events: none;
-  z-index: 5;
   font-size: clamp(1rem, 2.5vw, 1.5rem);
   color: #aaa;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -48,6 +48,11 @@ function App() {
         />
       </div>
       <div className="right-panel">
+        {!viewerLoaded && (
+          <div className="load-placeholder">
+            Welcome to LeaderPrompt. Please load or create a script.
+          </div>
+        )}
         <ScriptViewer
           projectName={selectedProject}
           scriptName={selectedScript}
@@ -64,34 +69,29 @@ function App() {
             setSendCallback(() => cb);
           }}
         />
-          {(closeCallback || sendCallback) && (
-            <div className="send-button-container">
-              {closeCallback && (
-                <button
-                  className="send-button"
-                  onClick={() => closeCallback && closeCallback()}
-                >
-                  Close
-                </button>
-              )}
-              {sendCallback && (
-                <button
-                  className="send-button"
-                  onClick={() => sendCallback && sendCallback()}
-                  disabled={!sendCallback}
-                >
-                  Let&apos;s Go!
-                </button>
-              )}
-            </div>
-          )}
+        {(closeCallback || sendCallback) && (
+          <div className="send-button-container">
+            {closeCallback && (
+              <button
+                className="send-button"
+                onClick={() => closeCallback && closeCallback()}
+              >
+                Close
+              </button>
+            )}
+            {sendCallback && (
+              <button
+                className="send-button"
+                onClick={() => sendCallback && sendCallback()}
+                disabled={!sendCallback}
+              >
+                Let&apos;s Go!
+              </button>
+            )}
+          </div>
+        )}
         <img src={leaderLogo} alt="LeaderPrompt Logo" className="main-logo" />
       </div>
-      {!viewerLoaded && (
-        <div className="load-placeholder">
-          Welcome to LeaderPrompt. Please load or create a script.
-        </div>
-      )}
     </div>
   );
 }

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
   position: relative;
   align-items: center;
   background-color: #1e1e1e;
@@ -33,6 +34,7 @@
 
 .script-viewer-content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 2vw;
@@ -100,7 +102,8 @@
 
 .script-content {
   outline: none;
-  flex-grow: 1;
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE and Edge */


### PR DESCRIPTION
## Summary
- make right panel a full-height flex column
- drop absolute/ sticky positioning for main logo, send buttons and placeholder
- keep editor areas stretchable via flex
- adjust App markup for new flex layout

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e8922fd8083218c1eb607781d6d6c