### PR TITLE
Allow script viewer to fill width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,7 @@ body {
 .main-layout {
   display: flex;
   height: 100vh;
+  width: 100%;
   overflow: hidden;
   position: relative;
 }
@@ -32,7 +33,7 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   padding: 2vw;
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -3,6 +3,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  width: 100%;
   position: relative;
   align-items: center;
   background-color: #1e1e1e;


### PR DESCRIPTION
## Summary
- ensure main layout stretches across the viewport
- stretch children in the right panel so the script viewer isn't centered
- give the script viewer an explicit width so it can use available space

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e8de2f9d0832180a98d8cd042e2e9