### PR TITLE
Add responsive left panel and adjust window limits

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -153,8 +153,8 @@ function createMainWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
-    minWidth: 1200,
-    minHeight: 800,
+    minWidth: 800,
+    minHeight: 600,
     webPreferences: {
       preload: path.resolve(__dirname, 'preload.cjs'),
       contextIsolation: true,

--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,9 @@ body {
   overflow-y: auto;
   overflow-x: visible;
 }
+.left-panel.collapsed {
+  display: none;
+}
 
 .right-panel {
   flex: 1;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import './App.css';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
 import leaderLogo from './assets/LeaderPass-Logo-white.png';
@@ -13,6 +13,19 @@ function App() {
   const [sendCallback, setSendCallback] = useState(null);
   const [closeCallback, setCloseCallback] = useState(null);
   const [viewerLoaded, setViewerLoaded] = useState(false);
+  const [showFileManager, setShowFileManager] = useState(() => window.innerWidth >= 1000);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth < 1000) {
+        setShowFileManager(false);
+      } else {
+        setShowFileManager(true);
+      }
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   const handleScriptSelect = (projectName, scriptName) => {
     setSelectedProject(projectName);
@@ -37,15 +50,17 @@ function App() {
 
  return (
   <div className="main-layout">
-    <div className="left-panel">
-      <FileManager
-        ref={fileManagerRef}
-        onScriptSelect={handleScriptSelect}
-        loadedProject={loadedProject}
-        loadedScript={loadedScript}
-        currentProject={selectedProject}
-        currentScript={selectedScript}
-      />
+    <div className={`left-panel ${showFileManager ? '' : 'collapsed'}`}>
+      {showFileManager && (
+        <FileManager
+          ref={fileManagerRef}
+          onScriptSelect={handleScriptSelect}
+          loadedProject={loadedProject}
+          loadedScript={loadedScript}
+          currentProject={selectedProject}
+          currentScript={selectedScript}
+        />
+      )}
     </div>
     <div className="right-panel">
       <ScriptViewer


### PR DESCRIPTION
## Summary
- relax minimum Electron window size
- toggle FileManager visibility based on window width
- hide left panel with a `collapsed` class when needed

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ad2a7fb7883218b5c954efcc23602