### PR TITLE
Add repo metadata and packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Edits made in the script editor are automatically written back to the underlying
 `html-to-docx` and saves it to the selected project/script location via the new
 `save-script` IPC handler exposed as
 `window.electronAPI.saveScript(projectName, scriptName, html)`.
+
+## Packaging and Releases
+
+Run `npm run package` on a Mac to build the application. Electron Builder will
+generate `dmg` and `zip` files in the `release` directory. Releases are
+published to GitHub so the app can receive updates through `electron-updater`.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "leaderprompt",
   "private": true,
   "version": "0.0.0",
+  "repository": "https://github.com/yourname/leaderprompt",
   "type": "module",
   "main": "electron/main.cjs",
   "build": {
@@ -16,7 +17,13 @@
     ],
     "win": {
       "target": "nsis"
-    }
+    },
+    "mac": {
+      "target": ["dmg", "zip"]
+    },
+    "publish": [
+      { "provider": "github" }
+    ]
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- set repository URL in package.json
- configure macOS build targets and GitHub publish in electron-builder config
- document how to package the app on macOS and how releases publish updates

## Testing
- `npm run lint`
- `npm run build`
- `npm run package`


------
https://chatgpt.com/codex/tasks/task_e_688ad47c5860832190ad003b7aa45d97