### PR TITLE
Enable dropping scripts onto project headers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -215,6 +215,11 @@ body {
   display: flex;
 }
 
+.project-header.drop-target {
+  border: 1px dashed var(--accent-color);
+  border-radius: 4px;
+}
+
 .project-group.collapsed ul {
   display: none;
 }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -86,6 +86,7 @@ const FileManager = forwardRef(function FileManager({
   const [confirmState, setConfirmState] = useState(null);
   const [dragInfo, setDragInfo] = useState(null);
   const [hoverIndex, setHoverIndex] = useState(null);
+  const [hoverProject, setHoverProject] = useState(null);
 
 
   useEffect(() => {
@@ -275,6 +276,21 @@ const FileManager = forwardRef(function FileManager({
     setHoverIndex((prev) => (prev === index ? null : prev));
   };
 
+  const handleProjectDragEnter = (projectName) => {
+    setHoverProject(projectName);
+  };
+
+  const handleProjectDragLeave = (projectName) => {
+    setHoverProject((prev) => (prev === projectName ? null : prev));
+  };
+
+  const handleProjectDrop = (e, projectName) => {
+    const proj = projects.find((p) => p.name === projectName);
+    const index = proj ? proj.scripts.length : -1;
+    handleDrop(e, projectName, index);
+    setHoverProject(null);
+  };
+
   const handleDrop = async (e, projectName, index) => {
     e.preventDefault();
     if (!dragInfo) return;
@@ -355,7 +371,13 @@ const FileManager = forwardRef(function FileManager({
             className={`project-group${collapsed[project.name] ? ' collapsed' : ''}`}
             key={project.name}
           >
-            <div className="project-header">
+            <div
+              className={`project-header${hoverProject === project.name ? ' drop-target' : ''}`}
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleProjectDrop(e, project.name)}
+              onDragEnter={() => handleProjectDragEnter(project.name)}
+              onDragLeave={() => handleProjectDragLeave(project.name)}
+            >
               {renamingProject === project.name ? (
                 <>
                   <input


### PR DESCRIPTION
## Summary
- support dropping onto project header areas
- highlight headers when dragged over

## Testing
- `npm run lint` *(fails: Parsing error in App.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_688ad715ccf08321b032b3dee2da5e79