### PR TITLE
Add packaging icon paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Ignore node modules and build files
 node_modules/
 dist/
-build/
+build/*
+!build/icons/
+!build/icons/README.md
 out/
 release/
 *.log

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Edits made in the script editor are automatically written back to the underlying
 Run `npm run package` on a Mac to build the application. Electron Builder will
 generate `dmg` and `zip` files in the `release` directory. Releases are
 published to GitHub so the app can receive updates through `electron-updater`.
+
+Packaged apps use icons from the `build/icons` directory. Provide
+`icon.ico` for Windows and `icon.icns` for macOS in that folder before
+running `npm run package`.

--- a/build/icons/README.md
+++ b/build/icons/README.md
@@ -1,0 +1,2 @@
+Place custom icons here for Electron Builder.
+Name the Windows icon `icon.ico` and the macOS icon `icon.icns`.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "build": {
     "appId": "com.yourcompany.leaderprompt",
     "productName": "LeaderPrompt",
+    "icon": "build/icons/icon",
     "directories": {
       "output": "release"
     },
@@ -16,10 +17,12 @@
       "electron/**/*"
     ],
     "win": {
-      "target": "nsis"
+      "target": "nsis",
+      "icon": "build/icons/icon.ico"
     },
     "mac": {
-      "target": ["dmg", "zip"]
+      "target": ["dmg", "zip"],
+      "icon": "build/icons/icon.icns"
     },
     "publish": [
       { "provider": "github" }


### PR DESCRIPTION
## Summary
- configure icon paths for electron-builder in `package.json`
- document where to put icon files for packaging
- allow committing icon files under `build/icons`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688add83b18c8321b2fac54721d1f157