### PR TITLE
Sanitize script names during rename

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -549,15 +549,25 @@ app.whenReady().then(async () => {
   ipcMain.handle('rename-script', async (_, projectName, oldName, newName) => {
     log(`Renaming script: ${oldName} -> ${newName} in ${projectName}`);
     if (!projectName || !oldName || !newName || oldName === newName) return false;
+
+    const safeName = sanitizeFilename(newName);
+    if (!safeName) {
+      error('Invalid sanitized script name:', newName);
+      return false;
+    }
+
     try {
       const base = path.join(getProjectsPath(), projectName);
       const oldPath = path.join(base, oldName);
-      let targetName = newName;
+
+      let targetName = safeName;
       if (!targetName.toLowerCase().endsWith('.docx')) {
         targetName += '.docx';
       }
+
       const newPath = path.join(base, targetName);
       if (!fs.existsSync(oldPath) || fs.existsSync(newPath)) return false;
+
       fs.renameSync(oldPath, newPath);
       return true;
     } catch (err) {

--- a/tests/rename-script.test.cjs
+++ b/tests/rename-script.test.cjs
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const test = require('node:test');
+const assert = require('node:assert');
+
+function sanitizeFilename(name) {
+  if (!name || typeof name !== 'string') return null;
+  const base = path.basename(name);
+  const sanitized = base.replace(/[\\/:*?"<>|]/g, '_').trim();
+  if (!sanitized || sanitized === '.' || sanitized === '..') return null;
+  return sanitized;
+}
+
+function renameScript(base, oldName, newName) {
+  if (!base || !oldName || !newName || oldName === newName) return false;
+  const safeName = sanitizeFilename(newName);
+  if (!safeName) return false;
+  let targetName = safeName;
+  if (!targetName.toLowerCase().endsWith('.docx')) {
+    targetName += '.docx';
+  }
+  const oldPath = path.join(base, oldName);
+  const newPath = path.join(base, targetName);
+  if (!fs.existsSync(oldPath) || fs.existsSync(newPath)) return false;
+  fs.renameSync(oldPath, newPath);
+  return true;
+}
+
+test('renameScript returns false for invalid new name', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lp-test-'));
+  const oldPath = path.join(dir, 'old.docx');
+  fs.writeFileSync(oldPath, 'dummy');
+  const result = renameScript(dir, 'old.docx', '..');
+  assert.strictEqual(result, false);
+  assert.ok(fs.existsSync(oldPath));
+});
+
+test('renameScript renames valid file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lp-test-'));
+  const oldPath = path.join(dir, 'old.docx');
+  fs.writeFileSync(oldPath, 'dummy');
+  const result = renameScript(dir, 'old.docx', 'new');
+  assert.strictEqual(result, true);
+  assert.ok(fs.existsSync(path.join(dir, 'new.docx')));
+  assert.ok(!fs.existsSync(oldPath));
+});


### PR DESCRIPTION
## Summary
- sanitize new script name before renaming
- add simple tests for script rename helper

## Testing
- `node --test tests/rename-script.test.cjs`

------
https://chatgpt.com/codex/tasks/task_e_688ae6d893c48321aaeaf8e7e5633e4e