### PR TITLE
Enable header toggles & default collapsed state

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -172,6 +172,7 @@ body {
   display: flex;
   align-items: center;
   gap: var(--space-1);
+  cursor: pointer;
 }
 
 .toggle-button {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -101,7 +101,7 @@ const FileManager = forwardRef(function FileManager({
         const next = { ...prev };
         result.forEach((p) => {
           if (typeof next[p.name] === 'undefined') {
-            next[p.name] = false;
+            next[p.name] = true;
           }
         });
         return next;
@@ -390,10 +390,16 @@ const FileManager = forwardRef(function FileManager({
                 </>
               ) : (
                 <>
-                  <div className="project-title">
+                  <div
+                    className="project-title"
+                    onClick={() => toggleCollapse(project.name)}
+                  >
                     <button
                       className="toggle-button"
-                      onClick={() => toggleCollapse(project.name)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleCollapse(project.name);
+                      }}
                     >
                       {collapsed[project.name] ? '▶' : '▼'}
                     </button>


### PR DESCRIPTION
## Summary
- default all projects to collapsed on initial load
- allow clicking a project header to toggle collapsed state
- show pointer cursor for clickable project titles

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ae78098588321aa2de4ae9e5335fe