### PR TITLE
Add auto update progress notifications

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -73,4 +73,27 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.send('set-prompter-bounds', bounds),
 
   prompterReady: () => ipcRenderer.send('prompter-ready'),
+
+  checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+  restartAndInstall: () => ipcRenderer.invoke('quit-and-install'),
+  onUpdateChecking: (callback) => {
+    const handler = () => callback()
+    ipcRenderer.on('checking-for-update', handler)
+    return () => ipcRenderer.removeListener('checking-for-update', handler)
+  },
+  onUpdateAvailable: (callback) => {
+    const handler = (_, info) => callback(info)
+    ipcRenderer.on('update-available', handler)
+    return () => ipcRenderer.removeListener('update-available', handler)
+  },
+  onUpdateProgress: (callback) => {
+    const handler = (_, progress) => callback(progress)
+    ipcRenderer.on('download-progress', handler)
+    return () => ipcRenderer.removeListener('download-progress', handler)
+  },
+  onUpdateDownloaded: (callback) => {
+    const handler = (_, info) => callback(info)
+    ipcRenderer.on('update-downloaded', handler)
+    return () => ipcRenderer.removeListener('update-downloaded', handler)
+  },
 });

--- a/src/Updater.jsx
+++ b/src/Updater.jsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+import { toast } from 'react-hot-toast'
+
+function Updater() {
+  useEffect(() => {
+    window.electronAPI.checkForUpdates()
+
+    const cleanChecking = window.electronAPI.onUpdateChecking(() => {
+      toast.loading('Checking for updates...', { id: 'update-check' })
+    })
+
+    const cleanAvailable = window.electronAPI.onUpdateAvailable((info) => {
+      toast.loading(`Downloading update ${info?.version || ''}...`, { id: 'update-download' })
+    })
+
+    const cleanProgress = window.electronAPI.onUpdateProgress((progress) => {
+      const percent = Math.round(progress.percent || 0)
+      toast.loading(`Downloading update... ${percent}%`, { id: 'update-download' })
+    })
+
+    const cleanDownloaded = window.electronAPI.onUpdateDownloaded(() => {
+      toast.dismiss('update-check')
+      toast.dismiss('update-download')
+      toast((t) => (
+        <span>
+          Update ready.
+          <button onClick={() => { window.electronAPI.restartAndInstall(); toast.dismiss(t.id) }}>Restart</button>
+        </span>
+      ), { duration: Infinity })
+    })
+
+    return () => {
+      cleanChecking?.()
+      cleanAvailable?.()
+      cleanProgress?.()
+      cleanDownloaded?.()
+    }
+  }, [])
+
+  return null
+}
+
+export default Updater

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import './index.css'
 import App from './App.jsx'
 import Prompter from './Prompter.jsx'
 import DevConsole from './DevConsole.jsx'
+import Updater from './Updater.jsx'
 
 export function DevIcon() {
   return (
@@ -37,6 +38,7 @@ createRoot(document.getElementById('root')).render(
       >
         <DevIcon />
       </button>
+      <Updater />
       <Toaster position="top-right" />
     </HashRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- emit more autoUpdater events in Electron main process
- expose update APIs from preload
- display update progress and restart prompts via a new Updater React component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ae6d3728883219cf5d17ec9b9db13