### PR TITLE
Add Stop Prompting button

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -166,3 +166,16 @@
   background: var(--accent-color);
   color: #000;
 }
+
+.stop-button {
+  background-color: #bb4444;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 4px;
+}
+
+.stop-button:hover {
+  background-color: #dd5555;
+}

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -197,6 +197,12 @@ function Prompter() {
         </button>
         <div className={`main-settings ${mainSettingsOpen ? 'open' : ''}`}>
         <button
+          className="stop-button"
+          onClick={() => window.electronAPI.closePrompter()}
+        >
+          Stop Prompting
+        </button>
+        <button
           className={`toggle-btn ${autoscroll ? 'active' : ''}`}
           onClick={() => setAutoscroll(!autoscroll)}
           disabled={notecardMode}


### PR DESCRIPTION
## Summary
- add a Stop Prompting button to the prompter settings
- style the Stop Prompting button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ae94cb840832196eb1f4fc64b1920