### PR TITLE
Fix update toasts

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -86,6 +86,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('update-available', handler)
     return () => ipcRenderer.removeListener('update-available', handler)
   },
+  onUpdateNotAvailable: (callback) => {
+    const handler = () => callback()
+    ipcRenderer.on('update-not-available', handler)
+    return () => ipcRenderer.removeListener('update-not-available', handler)
+  },
+  onUpdateError: (callback) => {
+    const handler = (_, message) => callback(message)
+    ipcRenderer.on('update-error', handler)
+    return () => ipcRenderer.removeListener('update-error', handler)
+  },
   onUpdateProgress: (callback) => {
     const handler = (_, progress) => callback(progress)
     ipcRenderer.on('download-progress', handler)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leaderprompt",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leaderprompt",
-      "version": "0.0.0",
+      "version": "1.0.0",
       "dependencies": {
         "docx": "^9.5.1",
         "electron-updater": "^6.6.2",

--- a/src/Updater.jsx
+++ b/src/Updater.jsx
@@ -13,6 +13,17 @@ function Updater() {
       toast.loading(`Downloading update ${info?.version || ''}...`, { id: 'update-download' })
     })
 
+    const cleanNotAvailable = window.electronAPI.onUpdateNotAvailable(() => {
+      toast.dismiss('update-check')
+      toast('No updates available.')
+    })
+
+    const cleanError = window.electronAPI.onUpdateError((message) => {
+      toast.dismiss('update-check')
+      toast.dismiss('update-download')
+      toast.error(`Update error: ${message}`)
+    })
+
     const cleanProgress = window.electronAPI.onUpdateProgress((progress) => {
       const percent = Math.round(progress.percent || 0)
       toast.loading(`Downloading update... ${percent}%`, { id: 'update-download' })
@@ -32,6 +43,8 @@ function Updater() {
     return () => {
       cleanChecking?.()
       cleanAvailable?.()
+      cleanNotAvailable?.()
+      cleanError?.()
       cleanProgress?.()
       cleanDownloaded?.()
     }


### PR DESCRIPTION
## Summary
- wire up `update-not-available` and `update-error` events
- show/dismiss toasts for no update found and update errors
- keep lockfile version in sync with `package.json`

## Testing
- `node --test tests/rename-script.test.cjs`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688af0cd890c8321b9b3dec347c78144