### PR TITLE
feat: edit scripts directly in prompter

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -408,6 +408,9 @@ app.whenReady().then(async () => {
     if (prompterWindow && !prompterWindow.isDestroyed()) {
       prompterWindow.webContents.send('update-script', html);
     }
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('update-script', html);
+    }
     log('Updated script content');
   });
 

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
+import TipTapEditor from './TipTapEditor.jsx'
 import './Prompter.css'
 
 const MARGIN_MIN = 0
@@ -21,11 +22,17 @@ function Prompter() {
   const [textAlign, setTextAlign] = useState('left')
   const [notecardMode, setNotecardMode] = useState(false)
   const [transparentMode, setTransparentMode] = useState(false)
+  const [editing, setEditing] = useState(false)
   const [slides, setSlides] = useState([])
   const [currentSlide, setCurrentSlide] = useState(0)
   // all settings are now accessible from a single panel
   const [mainSettingsOpen, setMainSettingsOpen] = useState(false)
   const containerRef = useRef(null)
+
+  const handleEdit = (html) => {
+    setContent(html)
+    window.electronAPI.sendUpdatedScript(html)
+  }
 
   const resetDefaults = () => {
     setAutoscroll(false)
@@ -238,6 +245,19 @@ function Prompter() {
         >
           Transparent
         </button>
+        <button
+          className={`toggle-btn ${editing ? 'active' : ''}`}
+          onClick={() => {
+            const next = !editing
+            setEditing(next)
+            if (next) {
+              setAutoscroll(false)
+              setNotecardMode(false)
+            }
+          }}
+        >
+          {editing ? 'Done Editing' : 'Edit Script'}
+        </button>
         <h4>Text Styling</h4>
         <label>
           Font Size ({fontSize}rem):
@@ -325,10 +345,17 @@ function Prompter() {
             transparentMode && strokeWidth > 0 ? `${strokeWidth}px black` : '0',
           overflowY: notecardMode ? 'hidden' : 'scroll',
         }}
-        dangerouslySetInnerHTML={{
-          __html: notecardMode ? slides[currentSlide] || '' : content,
-        }}
-      />
+      >
+        {editing ? (
+          <TipTapEditor initialHtml={content} onUpdate={handleEdit} />
+        ) : (
+          <div
+            dangerouslySetInnerHTML={{
+              __html: notecardMode ? slides[currentSlide] || '' : content,
+            }}
+          />
+        )}
+      </div>
       {notecardMode && slides.length > 1 && (
         <div className="notecard-controls">
           <button

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -61,6 +61,26 @@ useEffect(() => {
     }
   };
 
+  useEffect(() => {
+    const cleanup = window.electronAPI.onScriptUpdated((html) => {
+      if (html !== scriptHtml) {
+        setScriptHtml(html);
+        if (projectName && scriptName) {
+          if (saveTimeout.current) {
+            clearTimeout(saveTimeout.current);
+          }
+          saveTimeout.current = setTimeout(() => {
+            window.electronAPI.saveScript(projectName, scriptName, html);
+            saveTimeout.current = null;
+          }, 300);
+        }
+      }
+    });
+    return () => {
+      cleanup?.();
+    };
+  }, [scriptHtml, projectName, scriptName]);
+
 
   const handleSend = useCallback(() => {
     window.electronAPI.openPrompter(scriptHtml || '');
@@ -69,7 +89,7 @@ useEffect(() => {
 
   useEffect(() => {
     onSend?.(loaded && scriptHtml?.trim() ? () => handleSend() : null);
-  }, [onSend, handleSend, loaded]);
+  }, [onSend, handleSend, loaded, scriptHtml]);
 
   useEffect(() => {
     const cleanup = window.electronAPI.onPrompterClosed(() => {
@@ -95,7 +115,7 @@ useEffect(() => {
     onCloseViewer?.();
   }, [projectName, scriptName, scriptHtml, onPrompterClose, onCloseViewer]);
 
-  useEffect(() => () => handleClose(), []);
+  useEffect(() => () => handleClose(), [handleClose]);
 
   useEffect(() => {
     onLoadedChange?.(loaded);


### PR DESCRIPTION
## Summary
- allow toggling an edit mode in the prompter using TipTap editor
- keep script viewer in sync with prompter edits and auto-save
- broadcast script updates to both main and prompter windows

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896be0d432c8321a8927455fb514759