### PR TITLE
Add context menu formatting options for text editor

### DIFF
--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -1,0 +1,29 @@
+.tiptap-editor {
+  position: relative;
+}
+
+.editor-context-menu {
+  position: absolute;
+  z-index: 1000;
+  background: #333;
+  color: #e0e0e0;
+  border: 1px solid #555;
+  border-radius: 4px;
+  padding: 4px 0;
+  min-width: 140px;
+}
+
+.editor-context-menu button {
+  display: block;
+  width: 100%;
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 4px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.editor-context-menu button:hover {
+  background: #555;
+}

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -1,23 +1,92 @@
-import { useEffect } from 'react';
-import { useEditor, EditorContent } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
+import { useEffect, useState } from 'react'
+import { useEditor, EditorContent } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import './TipTapEditor.css'
 
 function TipTapEditor({ initialHtml = '', onUpdate }) {
   const editor = useEditor({
     extensions: [StarterKit],
     content: initialHtml,
     onUpdate: ({ editor }) => {
-      onUpdate?.(editor.getHTML());
+      onUpdate?.(editor.getHTML())
     },
-  });
+  })
+
+  const [menuPos, setMenuPos] = useState(null)
+
+  const apply = (action) => {
+    action()
+    setMenuPos(null)
+  }
+
+  const handleContextMenu = (e) => {
+    e.preventDefault()
+    setMenuPos({ x: e.clientX, y: e.clientY })
+  }
+
+  useEffect(() => {
+    const hide = () => setMenuPos(null)
+    window.addEventListener('click', hide)
+    return () => window.removeEventListener('click', hide)
+  }, [])
 
   useEffect(() => {
     if (editor && initialHtml !== editor.getHTML()) {
-      editor.commands.setContent(initialHtml);
+      editor.commands.setContent(initialHtml)
     }
-  }, [initialHtml, editor]);
+  }, [initialHtml, editor])
 
-  return <EditorContent editor={editor} />;
+  return (
+    <div className="tiptap-editor" onContextMenu={handleContextMenu}>
+      <EditorContent editor={editor} />
+      {menuPos && editor && (
+        <div
+          className="editor-context-menu"
+          style={{ top: menuPos.y, left: menuPos.x }}
+        >
+          <button
+            onClick={() =>
+              apply(() => editor.chain().focus().toggleBold().run())
+            }
+          >
+            Bold
+          </button>
+          <button
+            onClick={() =>
+              apply(() => editor.chain().focus().toggleItalic().run())
+            }
+          >
+            Italic
+          </button>
+          <button
+            onClick={() =>
+              apply(() => editor.chain().focus().setParagraph().run())
+            }
+          >
+            Normal
+          </button>
+          <button
+            onClick={() =>
+              apply(() =>
+                editor.chain().focus().toggleHeading({ level: 1 }).run()
+              )
+            }
+          >
+            Heading 1
+          </button>
+          <button
+            onClick={() =>
+              apply(() =>
+                editor.chain().focus().toggleHeading({ level: 2 }).run()
+              )
+            }
+          >
+            Heading 2
+          </button>
+        </div>
+      )}
+    </div>
+  )
 }
 
-export default TipTapEditor;
+export default TipTapEditor


### PR DESCRIPTION
## Summary
- add custom context menu to TipTap editor to apply formatting
- allow bold, italic, and heading level changes from the context menu

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896bf80625083218e1f46ca087bc386