### PR TITLE
Avoid stale script capture in ScriptViewer

### DIFF
--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -88,9 +88,9 @@ useEffect(() => {
 
 
   const handleSend = useCallback(() => {
-    window.electronAPI.openPrompter(scriptHtml || '');
+    window.electronAPI.openPrompter(scriptHtmlRef.current || '');
     onPrompterOpen?.(projectName, scriptName);
-  }, [scriptHtml, projectName, scriptName, onPrompterOpen]);
+  }, [projectName, scriptName, onPrompterOpen]);
 
   useEffect(() => {
     onSend?.(loaded && scriptHtml?.trim() ? () => handleSend() : null);


### PR DESCRIPTION
## Summary
- Avoid stale script captures by reading from `scriptHtmlRef` in `handleSend`
- Simplify `handleSend`'s dependencies to exclude `scriptHtml`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'editing' is not defined in src/Prompter.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6899edc48b3c8321a6ed4e4516f5bd09