### PR TITLE
Send prompter script after renderer is ready

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -386,6 +386,8 @@ app.whenReady().then(async () => {
       if (prompterWindow && !prompterWindow.isDestroyed()) {
         prompterWindow.show();
         prompterWindow.focus();
+        prompterWindow.setAlwaysOnTop(isAlwaysOnTop);
+        prompterWindow.webContents.send('load-script', currentScriptHtml);
         log('Prompter window shown');
       }
     };
@@ -395,11 +397,6 @@ app.whenReady().then(async () => {
       await createPrompterWindow();
     } else {
       showWindow();
-    }
-
-    if (prompterWindow && !prompterWindow.isDestroyed()) {
-      prompterWindow.setAlwaysOnTop(isAlwaysOnTop);
-      prompterWindow.webContents.send('load-script', currentScriptHtml);
     }
   });
 


### PR DESCRIPTION
## Summary
- Defer prompter script load until the renderer signals `prompter-ready`
- Move load and always-on-top logic into the `showWindow` helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-undef errors in src/Prompter.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6899f0dc3fb88321b2c293341e4c2e0b