### PR TITLE
Allow continuous editing in prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -10,6 +10,7 @@
   color: #e0e0e0;
   font-family: sans-serif;
   transform-origin: center;
+  position: relative;
 }
 
 
@@ -165,6 +166,30 @@
 .toggle-btn.active {
   background: var(--accent-color);
   color: #000;
+}
+
+.script-output {
+  pointer-events: none;
+}
+
+.editor-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.editor-overlay .tiptap-editor {
+  pointer-events: auto;
+  color: transparent;
+  caret-color: #e0e0e0;
+  background: transparent;
+}
+
+.editor-overlay .tiptap-editor .ProseMirror {
+  outline: none;
 }
 
 .stop-button {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -47,7 +47,6 @@ function Prompter() {
   const [currentSlide, setCurrentSlide] = useState(0)
   // all settings are now accessible from a single panel
   const [mainSettingsOpen, setMainSettingsOpen] = useState(false)
-  const [editing, setEditing] = useState(false)
   const containerRef = useRef(null)
 
   const handleEdit = (html) => {
@@ -326,19 +325,6 @@ function Prompter() {
         >
           Transparent
         </button>
-        <button
-          className={`toggle-btn ${editing ? 'active' : ''}`}
-          onClick={() => {
-            const next = !editing
-            setEditing(next)
-            if (next) {
-              setAutoscroll(false)
-              setNotecardMode(false)
-            }
-          }}
-        >
-          {editing ? 'Done Editing' : 'Edit Script'}
-        </button>
         <h4>Text Styling</h4>
         <label>
           Font Size ({fontSize}rem):
@@ -427,15 +413,15 @@ function Prompter() {
           overflowY: notecardMode ? 'hidden' : 'scroll',
         }}
       >
-        {editing ? (
+        <div
+          className="script-output"
+          dangerouslySetInnerHTML={{
+            __html: notecardMode ? slides[currentSlide] || '' : content,
+          }}
+        />
+        <div className="editor-overlay">
           <TipTapEditor initialHtml={content} onUpdate={handleEdit} />
-        ) : (
-          <div
-            dangerouslySetInnerHTML={{
-              __html: notecardMode ? slides[currentSlide] || '' : content,
-            }}
-          />
-        )}
+        </div>
       </div>
       {notecardMode && slides.length > 1 && (
         <div className="notecard-controls">


### PR DESCRIPTION
## Summary
- Remove edit-toggle state and keep TipTap editor mounted at all times
- Overlay transparent TipTap editor atop rendered script to allow simultaneous editing and prompting
- Add styles for editor overlay and script output

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899f2adf6cc8321bfa604a4ceb37c0a