### PR TITLE
Align editor overlay padding with script output

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -175,8 +175,9 @@
 .editor-overlay {
   position: absolute;
   top: 0;
-  left: 0;
   right: 0;
+  bottom: 0;
+  left: 0;
   pointer-events: none;
   z-index: 1;
 }

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -419,7 +419,10 @@ function Prompter() {
             __html: notecardMode ? slides[currentSlide] || '' : content,
           }}
         />
-        <div className="editor-overlay">
+        <div
+          className="editor-overlay"
+          style={{ padding: `2rem ${margin}px` }}
+        >
           <TipTapEditor initialHtml={content} onUpdate={handleEdit} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Apply same padding to editor overlay as the prompter container so text selection lines up with rendered script
- Expand editor overlay to span the full container bounds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899fb0ed5d48321a664a44fc734208b