### PR TITLE
Ensure TipTap editor uses full width

### DIFF
--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -1,3 +1,10 @@
+.tiptap-editor,
+.tiptap-editor .ProseMirror {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 .tiptap-editor {
   position: relative;
 }


### PR DESCRIPTION
## Summary
- ensure TipTap editor and its ProseMirror root fill the container width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node width check using jsdom`

------
https://chatgpt.com/codex/tasks/task_e_6899fcdda25c8321a2ad41ce7d6c8dc1