### PR TITLE
feat: import projects from dropped folders

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -36,6 +36,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Script import/load controls
   importScriptsToProject: (filePaths, projectName) =>
     ipcRenderer.invoke('import-scripts-to-project', filePaths, projectName),
+  importFoldersAsProjects: (folderPaths) =>
+    ipcRenderer.invoke('import-folders-as-projects', folderPaths),
   getScriptsForProject: (projectName) =>
     ipcRenderer.invoke('get-scripts-for-project', projectName),
   getAllProjectsWithScripts: () =>

--- a/src/App.css
+++ b/src/App.css
@@ -221,6 +221,10 @@ body {
   border-radius: 4px;
 }
 
+.file-manager-list.drop-target {
+  border: 2px dashed var(--accent-color);
+}
+
 .project-group.collapsed ul {
   display: none;
 }


### PR DESCRIPTION
## Summary
- allow dropping files onto project lists to import scripts
- support dropping folders to create projects and import contained .docx files
- highlight file manager when external items are dragged over

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899fe38cfe48321ac790684771110cc