### PR TITLE
Use descriptive labels for heading sizes

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -129,22 +129,26 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
               >
                 Normal
               </button>
-              {[1, 2, 3, 4].map((lvl) => (
-                <button
-                  key={lvl}
-                  onClick={() =>
-                    apply(() =>
-                      editor
-                        .chain()
-                        .focus()
-                        .toggleHeading({ level: lvl })
-                        .run()
-                    )
-                  }
-                >
-                  {`H${lvl}`}
-                </button>
-              ))}
+                {[
+                  { label: 'Big', level: 1 },
+                  { label: 'Medium', level: 2 },
+                  { label: 'Small', level: 3 },
+                ].map(({ label, level }) => (
+                  <button
+                    key={level}
+                    onClick={() =>
+                      apply(() =>
+                        editor
+                          .chain()
+                          .focus()
+                          .toggleHeading({ level })
+                          .run()
+                      )
+                    }
+                  >
+                    {label}
+                  </button>
+                ))}
             </div>
           )}
           {activeMenu === 'ai' && (


### PR DESCRIPTION
## Summary
- Replace numeric heading buttons with descriptive Big/Medium/Small labels

## Testing
- `npm test` (fails: Missing script "test")
- `node --test tests/rename-script.test.cjs`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a08f5c28c8321b63b59015ab88477