### PR TITLE
Keep color picker open in formatting menu

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -127,8 +127,14 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                   <input
                     type="color"
                     onChange={(e) =>
-                      apply(() =>
-                        document.execCommand('foreColor', false, e.target.value)
+                      apply(
+                        () =>
+                          document.execCommand(
+                            'foreColor',
+                            false,
+                            e.target.value
+                          ),
+                        false
                       )
                     }
                   />


### PR DESCRIPTION
## Summary
- Prevent formatting context menu from closing after selecting a color

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689a0eb38f4c8321a79bc8f02e84d718