### PR TITLE
Add persistent color formatting to TipTap editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.2",
       "dependencies": {
         "@tiptap/core": "^3.0.7",
+        "@tiptap/extension-color": "^3.0.7",
+        "@tiptap/extension-text-style": "^3.0.7",
         "@tiptap/react": "^3.0.7",
         "@tiptap/starter-kit": "^3.0.7",
         "docx": "^9.5.1",
@@ -2277,16 +2279,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.0.7.tgz",
-      "integrity": "sha512-/NC0BbekWzi5sC+s7gRrGIv33cUfuiZUG5DWx8TNedA6b6aTFPHUe+2wKRPaPQ0pfGdOWU0nsOkboUJ9dAjl4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-GDxoCrA+ggdzhUcelcWWVsMcmoOYXWmpjIviYXZTyHR/fds8G/mNjG0ZpFqXNmFnZ7Rs16bAsSX2tjDZ9MyTFg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.0.7"
+        "@tiptap/pm": "^3.1.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -2371,6 +2373,19 @@
       "peerDependencies": {
         "@tiptap/core": "^3.0.7",
         "@tiptap/pm": "^3.0.7"
+      }
+    },
+    "node_modules/@tiptap/extension-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-3.1.0.tgz",
+      "integrity": "sha512-ERE9eMpUFUpQMPvB1Z78Wi0Y4xPU0gwzpd4We8Km+pIX2VL4iIqA+rWouj/apaMTRdxs9uSECsS3vSfisrQPMw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-text-style": "^3.1.0"
       }
     },
     "node_modules/@tiptap/extension-document": {
@@ -2590,6 +2605,19 @@
         "@tiptap/core": "^3.0.7"
       }
     },
+    "node_modules/@tiptap/extension-text-style": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.1.0.tgz",
+      "integrity": "sha512-OPbOGD2SCSfosbzsr+nw9Uv2O14TpfYgCa8hIODLB7Sz1pRy3elqsAuIkA8G/po2TuPLD4Z4HxzL7dnPq/G5Lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.1.0"
+      }
+    },
     "node_modules/@tiptap/extension-underline": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.0.7.tgz",
@@ -2618,9 +2646,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.0.7.tgz",
-      "integrity": "sha512-f8PnWjYqbMCxny8cyjbFNeIyeOYLECTa/7gj8DJr53Ns+P94b4kYIt/GkveR5KoOxsbmXi8Uc4mjcR1giQPaIQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.1.0.tgz",
+      "integrity": "sha512-9Pjr+bC89/ATSl5J0UMVrr50TML3B5viDoMMpksgkSrnQSJyuGGfCc8DHd0TKydxucMcjVG/oq+evyCW9xXRRQ==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "@tiptap/core": "^3.0.7",
+    "@tiptap/extension-color": "^3.0.7",
+    "@tiptap/extension-text-style": "^3.0.7",
     "@tiptap/react": "^3.0.7",
     "@tiptap/starter-kit": "^3.0.7",
     "docx": "^9.5.1",

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import TextStyle from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
 import './TipTapEditor.css'
 
 const AI_SUGGESTIONS = [
@@ -12,7 +14,7 @@ const AI_SUGGESTIONS = [
 function TipTapEditor({ initialHtml = '', onUpdate }) {
   const containerRef = useRef(null)
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [StarterKit, TextStyle, Color],
     content: initialHtml,
     onUpdate: ({ editor }) => {
       onUpdate?.(editor.getHTML())
@@ -129,11 +131,11 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                     onChange={(e) =>
                       apply(
                         () =>
-                          document.execCommand(
-                            'foreColor',
-                            false,
-                            e.target.value
-                          ),
+                          editor
+                            .chain()
+                            .focus()
+                            .setColor(e.target.value)
+                            .run(),
                         false
                       )
                     }


### PR DESCRIPTION
## Summary
- import TipTap text-style and color extensions and include them in the editor
- replace `document.execCommand` with TipTap's `setColor` to persist color changes
- add color-related TipTap dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a1119d9748321959556f311fa9cb8