### PR TITLE
Use loadFile for local HTML windows

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import {TextstyleKit } from '@tiptap/extension-text-style'
+import TextStyle from '@tiptap/extension-text-style'
+import Color from '@tiptap/extension-color'
 import './TipTapEditor.css'
 
 const AI_SUGGESTIONS = [


### PR DESCRIPTION
## Summary
- Load local HTML via `BrowserWindow.loadFile` instead of `loadURL` in main, dev console, and prompter windows
- Fix TipTap editor imports so TextStyle and Color extensions resolve correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a13fb7468832197d619905743c2ca