### PR TITLE
Fix Metropolis font path

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import {TextstyleKit } from '@tiptap/extension-text-style'
+import { TextStyle, Color } from '@tiptap/extension-text-style'
 import './TipTapEditor.css'
 
 const AI_SUGGESTIONS = [

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'Metropolis-Bold';
-  src: url('../fonts/Metropolis-Bold.otf') format('opentype');
+  src: url('../public/fonts/Metropolis-Bold.otf') format('opentype');
   font-weight: 700;
   font-style: normal;
 }


### PR DESCRIPTION
## Summary
- point Metropolis Bold font-face to correct `public/fonts` location
- import `TextStyle` and `Color` from tiptap extension to satisfy lint and build

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a13fb9a3883218ec9209bdd06b1fe