### PR TITLE
Improve color picker usability in TipTapEditor

### DIFF
--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -49,8 +49,8 @@
 .color-wrapper input[type='color'] {
   position: absolute;
   left: -9999px;
-  width: 0;
-  height: 0;
+  width: 1px;
+  height: 1px;
   border: none;
   padding: 0;
 }

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -124,10 +124,18 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
               </button>
               <div className="color-wrapper">
                 <button
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     const sel = editor.state.selection
                     selectionRef.current = { from: sel.from, to: sel.to }
-                    colorInputRef.current?.click()
+                    const input = colorInputRef.current
+                    if (input) {
+                      if (input.showPicker) {
+                        input.showPicker()
+                      } else {
+                        input.click()
+                      }
+                    }
                   }}
                 >
                   🎨


### PR DESCRIPTION
## Summary
- Use `showPicker` when available and suppress `mousedown` default to keep text selection when choosing colors
- Size hidden color input minimally (1px) to remain interactive while off-screen

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689a220acf1c8321b56379d0f1fbd7ec