### PR TITLE
style: restyle ProseMirror editing area

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -191,6 +191,9 @@
 
 .editor-overlay .tiptap-editor .ProseMirror {
   outline: none;
+  background: transparent;
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .stop-button {

--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -10,6 +10,13 @@
   position: relative;
 }
 
+.tiptap-editor .ProseMirror {
+  outline: none;
+  background: #2a2a2a;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
 /* Context menu base */
 .context-menu-root {
   position: absolute;


### PR DESCRIPTION
## Summary
- remove ProseMirror outline in editor
- highlight editor with darker grey background, rounded corners, and shadow
- keep overlay editor transparent

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a23de24088321acd9eb9baf14a126