### PR TITLE
chore: add color picker debug logs

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -4,6 +4,12 @@ import StarterKit from '@tiptap/starter-kit'
 import { TextStyle, Color } from '@tiptap/extension-text-style'
 import './TipTapEditor.css'
 
+const DEBUG_COLOR_PICKER =
+  window.localStorage.getItem('DEBUG_COLOR_PICKER') !== 'false'
+const colorDebug = (...args) => {
+  if (DEBUG_COLOR_PICKER) console.log('[color]', ...args)
+}
+
 const AI_SUGGESTIONS = [
   'Lorem ipsum dolor sit amet',
   'Consectetur adipiscing elit',
@@ -24,6 +30,10 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   const [activeMenu, setActiveMenu] = useState('root')
   const colorInputRef = useRef(null)
   const selectionRef = useRef(null)
+
+  useEffect(() => {
+    colorDebug('debug logging active')
+  }, [])
 
   const openMenu = (pos) => {
     setMenuPos(pos)
@@ -68,8 +78,11 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   useEffect(() => {
     const hide = (e) => {
       if (!e.target.closest('.context-menu-root')) {
+        colorDebug('hide: click outside menu', e.target)
         setMenuPos(null)
         setActiveMenu('root')
+      } else {
+        colorDebug('hide: click inside menu, ignoring')
       }
     }
     window.addEventListener('mousedown', hide)
@@ -126,15 +139,32 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                 <button
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
+                    colorDebug('color button clicked')
                     const sel = editor.state.selection
                     selectionRef.current = { from: sel.from, to: sel.to }
                     const input = colorInputRef.current
-                    if (input) {
-                      if (input.showPicker) {
+                    if (!input) {
+                      colorDebug('color input ref missing')
+                      return
+                    }
+                    colorDebug('color input ref found')
+                    const supportsShowPicker = typeof input.showPicker === 'function'
+                    colorDebug('supports showPicker', supportsShowPicker)
+                    const styles = window.getComputedStyle(input)
+                    colorDebug('input styles', {
+                      display: styles.display,
+                      pointerEvents: styles.pointerEvents,
+                    })
+                    try {
+                      if (supportsShowPicker) {
                         input.showPicker()
+                        colorDebug('showPicker invoked')
                       } else {
+                        colorDebug('falling back to click()')
                         input.click()
                       }
+                    } catch (err) {
+                      colorDebug('failed to open color picker', err)
                     }
                   }}
                 >
@@ -147,6 +177,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                   onChange={(e) =>
                     apply(
                       () => {
+                        colorDebug('color input changed', e.target.value)
                         const { from, to } =
                           selectionRef.current || editor.state.selection
                         editor


### PR DESCRIPTION
## Summary
- add toggleable color picker debug logging to TipTapEditor
- log handler triggers, showPicker support, input styles, and debugging enabled state
- note when menu hides from outside clicks and when color changes occur

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a24075d0083219bb1662ec79e6a2a