### PR TITLE
Revert color picker to basic input

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -4,12 +4,6 @@ import StarterKit from '@tiptap/starter-kit'
 import { TextStyle, Color } from '@tiptap/extension-text-style'
 import './TipTapEditor.css'
 
-const DEBUG_COLOR_PICKER =
-  window.localStorage.getItem('DEBUG_COLOR_PICKER') !== 'false'
-const colorDebug = (...args) => {
-  if (DEBUG_COLOR_PICKER) console.log('[color]', ...args)
-}
-
 const AI_SUGGESTIONS = [
   'Lorem ipsum dolor sit amet',
   'Consectetur adipiscing elit',
@@ -31,10 +25,6 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   const [_menuHistory, setMenuHistory] = useState(['root'])
   const colorInputRef = useRef(null)
   const selectionRef = useRef(null)
-
-  useEffect(() => {
-    colorDebug('debug logging active')
-  }, [])
 
   const openMenu = (pos) => {
     setMenuPos(pos)
@@ -99,12 +89,9 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   useEffect(() => {
     const hide = (e) => {
       if (!e.target.closest('.context-menu-root')) {
-        colorDebug('hide: click outside menu', e.target)
         setMenuPos(null)
         setActiveMenu('root')
         setMenuHistory(['root'])
-      } else {
-        colorDebug('hide: click inside menu, ignoring')
       }
     }
     window.addEventListener('mousedown', hide)
@@ -162,35 +149,10 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
               </button>
               <div className="color-wrapper">
                 <button
-                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
-                    colorDebug('color button clicked')
                     const sel = editor.state.selection
                     selectionRef.current = { from: sel.from, to: sel.to }
-                    const input = colorInputRef.current
-                    if (!input) {
-                      colorDebug('color input ref missing')
-                      return
-                    }
-                    colorDebug('color input ref found')
-                    const supportsShowPicker = typeof input.showPicker === 'function'
-                    colorDebug('supports showPicker', supportsShowPicker)
-                    const styles = window.getComputedStyle(input)
-                    colorDebug('input styles', {
-                      display: styles.display,
-                      pointerEvents: styles.pointerEvents,
-                    })
-                    try {
-                      if (supportsShowPicker) {
-                        input.showPicker()
-                        colorDebug('showPicker invoked')
-                      } else {
-                        colorDebug('falling back to click()')
-                        input.click()
-                      }
-                    } catch (err) {
-                      colorDebug('failed to open color picker', err)
-                    }
+                    colorInputRef.current?.click()
                   }}
                 >
                   🎨
@@ -202,7 +164,6 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                   onChange={(e) =>
                     apply(
                       () => {
-                        colorDebug('color input changed', e.target.value)
                         const { from, to } =
                           selectionRef.current || editor.state.selection
                         editor


### PR DESCRIPTION
## Summary
- restore original color picker behavior by removing debug utilities and `showPicker` logic
- trigger color selection by clicking a hidden input, keeping the menu state intact

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a2920741083218950f04cf3657933