### PR TITLE
Fix spacing between action buttons and logo

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -391,7 +391,8 @@ body {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  padding: 1vw 2vw;
+  /* Add extra right padding so buttons don't overlap with the logo */
+  padding: 1vw 14vw 1vw 2vw;
   background-color: #1e1e1e;
   width: 100%;
   gap: var(--space-2);


### PR DESCRIPTION
## Summary
- prevent the "Let's Go" button from overlapping the LeaderPass logo by adding extra right padding to the button container

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a295731988321b4dda4416df6c350