### PR TITLE
Keep color picker open until blurred

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -187,7 +187,6 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                       },
                       false,
                     )
-                    setColorPickerOpen(false)
                   }}
                   onBlur={() => setColorPickerOpen(false)}
                 />


### PR DESCRIPTION
## Summary
- keep color picker open while adjusting text color by removing close call in change handler
- still close color picker when it loses focus

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3289b88483218daa9ad1d33bc0f3