### PR TITLE
feat: add rewrite selection handler

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -896,6 +896,49 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     }
   });
 
+  ipcMain.handle('rewrite-selection', async (event, { text }) => {
+    try {
+      if (!text) return [];
+      const apiKey = process.env.OPENAI_API_KEY;
+      if (!apiKey) {
+        log('OpenAI API key not set');
+        return [];
+      }
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Provide three alternative rewrites of the user text. Return each option as a short sentence.',
+            },
+            { role: 'user', content: text },
+          ],
+          n: 3,
+        }),
+        signal: event.signal,
+      });
+      const data = await res.json();
+      if (!data.choices) return [];
+      return data.choices
+        .map((c) => c.message?.content?.trim())
+        .filter(Boolean);
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        log('Rewrite selection aborted');
+        return [];
+      }
+      error('Rewrite selection failed:', err);
+      return [];
+    }
+  });
+
   ipcMain.handle('check-for-updates', () => {
     if (!ENABLE_AUTO_UPDATES) {
       log('Auto updates disabled');

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -50,6 +50,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
 
+  rewriteSelection: (text, signal) =>
+    ipcRenderer.invoke('rewrite-selection', { text }, { signal }),
+
   onLogMessage: (callback) => {
     const handler = (_, msg) => callback(msg)
     ipcRenderer.on('log-message', handler)

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -109,6 +109,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   }, [activeMenu, editor, selectedText])
 
   useEffect(() => {
+    if (!window.electronAPI?.rewriteSelection) return
     if (activeMenu !== 'ai' || !selectedText.trim()) return
     const controller = new AbortController()
     window.electronAPI


### PR DESCRIPTION
## Summary
- expose rewriteSelection IPC helper
- add main process handler that calls OpenAI for rewrite suggestions
- guard TipTap editor effect when API unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a3d99fd748321914b37ea91a2ec69