### PR TITLE
style: refine scrollbars

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -104,8 +104,6 @@
   outline: none;
   flex-grow: 1;
   overflow-y: auto;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* IE and Edge */
   padding: 0;
   background-color: #1e1e1e;
   font-family: sans-serif;
@@ -116,9 +114,6 @@
   word-break: break-word;
 }
 
-.script-content::-webkit-scrollbar {
-  display: none; /* Chrome, Safari and Opera */
-}
 
 
 .link-button {

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,34 @@
   box-sizing: border-box;
 }
 
+/* Global scrollbar styling */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #555 #2b2b2b;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+*::-webkit-scrollbar-track {
+  background: #2b2b2b;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: #555;
+  border-radius: 3px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: #777;
+}
+
+*::-webkit-scrollbar-button {
+  display: none;
+}
+
 :root {
   font-family: 'Metropolis-Bold', sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- add global thin scrollbar styling and hide arrow buttons
- remove script viewer's hidden scrollbars to show new style

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a40b734f08321b839500ad051cde1