### PR TITLE
Disable AI rework offline and embed OpenAI key

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -7,6 +7,10 @@ const mammoth = require('mammoth');
 const htmlToDocx = require('html-to-docx');
 const { spawn } = require('child_process');
 
+// Hard-coded OpenAI API key used by the rewrite feature. Replace the placeholder
+// string with a real key for production deployments.
+const OPENAI_API_KEY = 'REPLACE_WITH_OPENAI_KEY';
+
 // Toggle automatic update behavior with an environment variable. All update
 // logic remains in place so it can be re-enabled easily.
 const ENABLE_AUTO_UPDATES = process.env.ENABLE_AUTO_UPDATES === 'true';
@@ -899,7 +903,7 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
   ipcMain.handle('rewrite-selection', async (event, { text }) => {
     try {
       if (!text) return [];
-      const apiKey = process.env.OPENAI_API_KEY;
+      const apiKey = OPENAI_API_KEY;
       if (!apiKey) {
         log('OpenAI API key not set');
         return [];

--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -49,6 +49,11 @@
   background: #555;
 }
 
+.context-menu button:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
 .color-wrapper { position: relative; }
 
 .color-wrapper input[type='color'] {
@@ -111,6 +116,17 @@
   cursor: pointer;
   text-decoration: underline;
   padding: 0;
+}
+
+.network-warning {
+  margin-top: 4px;
+  background: #a00;
+  color: #fff;
+  border: 1px solid #f55;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.85em;
+  text-align: center;
 }
 
 .fade-in {

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -26,6 +26,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   const [error, setError] = useState(null)
   const [retryCount, setRetryCount] = useState(0)
   const loaderRef = useRef(null)
+  const [isOnline, setIsOnline] = useState(navigator.onLine)
 
   const openMenu = (pos) => {
     setMenuPos(pos)
@@ -67,6 +68,16 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
       openMenu({ x: e.clientX - rect.left, y: e.clientY - rect.top })
     }
   }
+
+  useEffect(() => {
+    const updateOnline = () => setIsOnline(navigator.onLine)
+    window.addEventListener('online', updateOnline)
+    window.addEventListener('offline', updateOnline)
+    return () => {
+      window.removeEventListener('online', updateOnline)
+      window.removeEventListener('offline', updateOnline)
+    }
+  }, [])
 
   useEffect(() => {
     if (!editor) return
@@ -180,11 +191,24 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
           onClick={(e) => e.stopPropagation()}
         >
           {activeMenu === 'root' && (
-            <div className="context-menu fade-in">
-              <button onClick={goBack}>x</button>
-              <button onClick={() => navigateTo('format')}>A</button>
-              <button onClick={() => navigateTo('ai')}>✨</button>
-            </div>
+            <>
+              <div className="context-menu fade-in">
+                <button onClick={goBack}>x</button>
+                <button onClick={() => navigateTo('format')}>A</button>
+                <button
+                  onClick={() => navigateTo('ai')}
+                  disabled={!isOnline}
+                  title={isOnline ? '' : 'No internet connection'}
+                >
+                  ✨
+                </button>
+              </div>
+              {!isOnline && (
+                <div className="network-warning fade-in">
+                  No internet connection
+                </div>
+              )}
+            </>
           )}
           {activeMenu === 'format' && (
             <div className="context-menu format fade-in">


### PR DESCRIPTION
## Summary
- Disable AI rework button when offline and show a clear network warning in the editor context menu
- Add placeholder OpenAI API key in main process and reference it in rewrite handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a475d537c8321ab8c038f9e49e6c2