### PR TITLE
feat: add rewrite selection handler

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -454,6 +454,46 @@ app.whenReady().then(async () => {
     log(`Prompter bounds set: ${JSON.stringify(bounds)}`);
   });
 
+  ipcMain.handle('rewrite-selection', async (_, text) => {
+    try {
+      if (!text) return [];
+      const truncated = text.slice(0, 1000);
+      log(`Rewrite selection request length: ${text.length}`);
+      const apiKey = OPENAI_API_KEY;
+      if (!apiKey) {
+        log('OpenAI API key not set');
+        return [];
+      }
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Provide three alternative rewrites of the user text. Return each option as a short sentence.',
+            },
+            { role: 'user', content: truncated },
+          ],
+          n: 3,
+        }),
+      });
+      const data = await res.json();
+      if (!data.choices) return [];
+      return data.choices
+        .map((c) => c.message?.content?.trim())
+        .filter(Boolean);
+    } catch (err) {
+      error('Rewrite selection failed:', err);
+      return [];
+    }
+  });
+
   ipcMain.handle('get-all-projects-with-scripts', async () => {
     log('Fetching all projects with scripts');
     try {
@@ -897,49 +937,6 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     } catch (err) {
       error('Failed to delete script:', err);
       return false;
-    }
-  });
-
-  ipcMain.handle('rewrite-selection', async (event, { text }) => {
-    try {
-      if (!text) return [];
-      const apiKey = OPENAI_API_KEY;
-      if (!apiKey) {
-        log('OpenAI API key not set');
-        return [];
-      }
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          model: 'gpt-4o-mini',
-          messages: [
-            {
-              role: 'system',
-              content:
-                'Provide three alternative rewrites of the user text. Return each option as a short sentence.',
-            },
-            { role: 'user', content: text },
-          ],
-          n: 3,
-        }),
-        signal: event.signal,
-      });
-      const data = await res.json();
-      if (!data.choices) return [];
-      return data.choices
-        .map((c) => c.message?.content?.trim())
-        .filter(Boolean);
-    } catch (err) {
-      if (err.name === 'AbortError') {
-        log('Rewrite selection aborted');
-        return [];
-      }
-      error('Rewrite selection failed:', err);
-      return [];
     }
   });
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -50,8 +50,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
 
-  rewriteSelection: (text, signal) =>
-    ipcRenderer.invoke('rewrite-selection', { text }, { signal }),
+  rewriteSelection: (text) => ipcRenderer.invoke('rewrite-selection', text),
 
   onLogMessage: (callback) => {
     const handler = (_, msg) => callback(msg)


### PR DESCRIPTION
## Summary
- add ipc handler for `rewrite-selection` that truncates input and calls OpenAI for alternatives
- update preload call to match new handler signature

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a498a878c83219605a7622cd08b41