### PR TITLE
Handle empty rewrite suggestions

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -462,7 +462,7 @@ app.whenReady().then(async () => {
       const apiKey = OPENAI_API_KEY;
       if (!apiKey) {
         log('OpenAI API key not set');
-        return [];
+        return { error: 'Missing OpenAI API key' };
       }
       const res = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
@@ -483,14 +483,18 @@ app.whenReady().then(async () => {
           n: 3,
         }),
       });
+      if (!res.ok) {
+        error('Rewrite selection request failed:', res.statusText);
+        return { error: 'Request failed' };
+      }
       const data = await res.json();
-      if (!data.choices) return [];
+      if (!data.choices) return { error: 'No suggestions' };
       return data.choices
         .map((c) => c.message?.content?.trim())
         .filter(Boolean);
     } catch (err) {
       error('Rewrite selection failed:', err);
-      return [];
+      return { error: 'Request failed' };
     }
   });
 
@@ -946,7 +950,7 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
       const apiKey = OPENAI_API_KEY;
       if (!apiKey) {
         log('OpenAI API key not set');
-        return [];
+        return { error: 'Missing OpenAI API key' };
       }
       const res = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
@@ -968,8 +972,12 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
         }),
         signal: event.signal,
       });
+      if (!res.ok) {
+        error('Rewrite selection request failed:', res.statusText);
+        return { error: 'Request failed' };
+      }
       const data = await res.json();
-      if (!data.choices) return [];
+      if (!data.choices) return { error: 'No suggestions' };
       return data.choices
         .map((c) => c.message?.content?.trim())
         .filter(Boolean);
@@ -979,7 +987,7 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
         return [];
       }
       error('Rewrite selection failed:', err);
-      return [];
+      return { error: 'Request failed' };
     }
   });
 

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -131,7 +131,12 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     window.electronAPI
       .rewriteSelection(selectedText, ctrl.signal)
       .then((res) => {
-        setSuggestions(res)
+        if (!Array.isArray(res) || res.length === 0) {
+          setError(true)
+          setSuggestions(['No suggestions available'])
+        } else {
+          setSuggestions(res)
+        }
         clearInterval(loaderRef.current)
         loaderRef.current = null
       })
@@ -140,7 +145,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
           setError(true)
           clearInterval(loaderRef.current)
           loaderRef.current = null
-          setSuggestions([])
+          setSuggestions(['No suggestions available'])
         }
       })
     return () => ctrl.abort()
@@ -313,7 +318,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
                 <div
                   key={i}
                   className="ai-line"
-                  onClick={() => replaceSelection(result)}
+                  onClick={!error ? () => replaceSelection(result) : undefined}
                 >
                   {result}
                 </div>


### PR DESCRIPTION
## Summary
- Show a friendly "No suggestions available" message when the AI rewrite API returns no results and prevent replacing the selection in that case.
- Return explicit error objects from the Electron rewrite handler when the OpenAI API key is missing or the request fails.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a4c00800c83218ed0a85890a68178