### PR TITLE
feat: externalize OpenAI API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - name: Package
+        run: npm run package
+        env:
+          # OPENAI_API_KEY is sourced from a GitHub secret managed and rotated
+          # centrally.
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -44,3 +44,25 @@ published to GitHub so the app can receive updates through `electron-updater`.
 Packaged apps use icons from the `build/icons` directory. Provide
 `icon.ico` for Windows and `icon.icns` for macOS in that folder before
 running `npm run package`.
+
+## API Key Management
+
+LeaderPrompt requires an OpenAI API key for rewrite features. The app reads the
+key from the `OPENAI_API_KEY` environment variable at runtime.
+
+### Local Development
+
+Store the key in `~/.config/leaderprompt/openai_api_key` and start the app with:
+
+```bash
+npm start
+```
+
+The bootstrap script loads the key from that file and launches the Electron
+process with the environment variable set, keeping the key outside the project.
+
+### CI/CD and Packaging
+
+CI pipelines should supply `OPENAI_API_KEY` from a centrally managed secret
+store. The included GitHub Actions workflow uses a repository secret named
+`OPENAI_API_KEY`. Rotate this secret centrally without modifying the codebase.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -7,9 +7,9 @@ const mammoth = require('mammoth');
 const htmlToDocx = require('html-to-docx');
 const { spawn } = require('child_process');
 
-// Hard-coded OpenAI API key used by the rewrite feature. Replace the placeholder
-// string with a real key for production deployments.
-const OPENAI_API_KEY = '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';
+// OpenAI API key is provided at runtime via the OPENAI_API_KEY environment
+// variable. The key should never be committed to source control.
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 
 // Model and prompt configuration for AI rewrites
 const OPENAI_MODEL = 'gpt-4o';

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "electron-dev": "electron electron/main.cjs",
-    "package": "electron-builder"
+    "start": "node scripts/bootstrap.mjs",
+    "package": "node scripts/package.mjs"
   },
   "dependencies": {
     "@tiptap/core": "^3.0.7",

--- a/scripts/bootstrap.mjs
+++ b/scripts/bootstrap.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { spawn } from 'child_process';
+import os from 'os';
+import path from 'path';
+
+const keyPath = path.join(os.homedir(), '.config', 'leaderprompt', 'openai_api_key');
+let apiKey;
+try {
+  apiKey = readFileSync(keyPath, 'utf8').trim();
+} catch (err) {
+  console.error(`Failed to read OpenAI API key from ${keyPath}`);
+  process.exit(1);
+}
+
+const child = spawn('npm', ['run', 'electron-dev'], {
+  stdio: 'inherit',
+  shell: true,
+  env: { ...process.env, OPENAI_API_KEY: apiKey },
+});
+
+child.on('exit', (code) => process.exit(code));

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { spawnSync } from 'child_process';
+import os from 'os';
+import path from 'path';
+
+const keyPath = path.join(os.homedir(), '.config', 'leaderprompt', 'openai_api_key');
+let apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) {
+  try {
+    apiKey = readFileSync(keyPath, 'utf8').trim();
+  } catch (err) {
+    console.error(`OPENAI_API_KEY not set and key file not found at ${keyPath}`);
+    process.exit(1);
+  }
+}
+
+const result = spawnSync('npx', ['electron-builder'], {
+  stdio: 'inherit',
+  shell: true,
+  env: { ...process.env, OPENAI_API_KEY: apiKey },
+});
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
## Summary
- load OpenAI API key from environment instead of hard-coding
- add bootstrap and package scripts to inject API key securely
- document central API key management and provide release workflow

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a99f5541c8321af62cd8c5206bd81