### PR TITLE
feat: load OpenAI key from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,38 @@ When running the Electron app in development, the main process now waits for the
 Vite dev server at `http://localhost:5173` to respond before creating any
 windows. This avoids reload loops while Vite is starting.
 
+## OpenAI Rewrite Feature
+
+LeaderPrompt can suggest alternative phrasings for selected text using OpenAI's
+API. The feature looks for an API key at startup and disables itself if none is
+available.
+
+### Local development
+
+Create a `.env` file in the project root containing:
+
+```
+OPENAI_API_KEY=sk-your-key
+```
+
+Restart the development server after adding the file.
+
+### Packaged builds
+
+Set the `OPENAI_API_KEY` environment variable before launching the application:
+
+```
+OPENAI_API_KEY=sk-your-key LeaderPrompt.app
+```
+
+Alternatively, create `~/leaderprompt/config.json` with:
+
+```
+{ "OPENAI_API_KEY": "sk-your-key" }
+```
+
+If the key is missing, the app logs an error and rewrite options are hidden.
+
 ## Script Persistence
 
 Edits made in the script editor are automatically written back to the underlying

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -7,9 +7,8 @@ const mammoth = require('mammoth');
 const htmlToDocx = require('html-to-docx');
 const { spawn } = require('child_process');
 
-// Hard-coded OpenAI API key used by the rewrite feature. Replace the placeholder
-// string with a real key for production deployments.
-const OPENAI_API_KEY = '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';
+let OPENAI_API_KEY;
+let ENABLE_REWRITES = false;
 
 // Model and prompt configuration for AI rewrites
 const OPENAI_MODEL = 'gpt-4o';
@@ -112,6 +111,39 @@ function stopViteServer() {
 const getUserDataPath = () => path.join(app.getPath('home'), 'leaderprompt');
 const getProjectsPath = () => path.join(getUserDataPath(), 'projects');
 const getProjectMetadataPath = () => path.join(getUserDataPath(), 'projects.json');
+
+function loadOpenAIKey() {
+  let key = process.env.OPENAI_API_KEY;
+
+  if (!key) {
+    try {
+      const envPath = path.join(__dirname, '..', '.env');
+      if (fs.existsSync(envPath)) {
+        const match = fs
+          .readFileSync(envPath, 'utf8')
+          .match(/^OPENAI_API_KEY=(.*)$/m);
+        if (match) key = match[1].trim();
+      }
+    } catch (err) {
+      error('Failed to read .env file:', err);
+    }
+  }
+
+  if (!key) {
+    try {
+      const cfgPath = path.join(getUserDataPath(), 'config.json');
+      if (fs.existsSync(cfgPath)) {
+        const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+        if (cfg.OPENAI_API_KEY) key = cfg.OPENAI_API_KEY;
+      }
+    } catch (err) {
+      error('Failed to read config file:', err);
+    }
+  }
+
+  if (key) process.env.OPENAI_API_KEY = key;
+  return key;
+}
 
 function sanitizeFilename(name) {
   if (!name || typeof name !== 'string') return null;
@@ -373,6 +405,11 @@ async function createPrompterWindow() {
 
 // --- Electron App Lifecycle ---
 app.whenReady().then(async () => {
+  OPENAI_API_KEY = loadOpenAIKey();
+  ENABLE_REWRITES = !!OPENAI_API_KEY;
+  if (!ENABLE_REWRITES) {
+    error('OpenAI API key not set. Rewrite features disabled.');
+  }
   log('App ready');
   startViteServer();
   if (!app.isPackaged) {
@@ -473,48 +510,50 @@ app.whenReady().then(async () => {
     log(`Prompter bounds set: ${JSON.stringify(bounds)}`);
   });
 
-  ipcMain.handle('rewrite-selection', async (_, text) => {
-    try {
-      if (!text) return [];
-      const truncated = text.slice(0, 1000);
-      log(`Rewrite selection request length: ${text.length}`);
-      const apiKey = OPENAI_API_KEY;
-      if (!apiKey) {
-        log('OpenAI API key not set');
-        return { error: 'Missing OpenAI API key' };
-      }
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          model: OPENAI_MODEL,
-          messages: [
-            {
-              role: 'system',
-              content: REWRITE_PROMPT,
-            },
-            { role: 'user', content: truncated },
-          ],
-          n: 3,
-        }),
-      });
-      if (!res.ok) {
-        error('Rewrite selection request failed:', res.statusText);
+  if (ENABLE_REWRITES) {
+    ipcMain.handle('rewrite-selection', async (_, text) => {
+      try {
+        if (!text) return [];
+        const truncated = text.slice(0, 1000);
+        log(`Rewrite selection request length: ${text.length}`);
+        const apiKey = OPENAI_API_KEY;
+        if (!apiKey) {
+          log('OpenAI API key not set');
+          return { error: 'Missing OpenAI API key' };
+        }
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model: OPENAI_MODEL,
+            messages: [
+              {
+                role: 'system',
+                content: REWRITE_PROMPT,
+              },
+              { role: 'user', content: truncated },
+            ],
+            n: 3,
+          }),
+        });
+        if (!res.ok) {
+          error('Rewrite selection request failed:', res.statusText);
+          return { error: 'Request failed' };
+        }
+        const data = await res.json();
+        if (!data.choices) return { error: 'No suggestions' };
+        return data.choices
+          .map((c) => c.message?.content?.trim())
+          .filter(Boolean);
+      } catch (err) {
+        error('Rewrite selection failed:', err);
         return { error: 'Request failed' };
       }
-      const data = await res.json();
-      if (!data.choices) return { error: 'No suggestions' };
-      return data.choices
-        .map((c) => c.message?.content?.trim())
-        .filter(Boolean);
-    } catch (err) {
-      error('Rewrite selection failed:', err);
-      return { error: 'Request failed' };
-    }
-  });
+    });
+  }
 
   ipcMain.handle('get-all-projects-with-scripts', async () => {
     log('Fetching all projects with scripts');
@@ -962,53 +1001,55 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     }
   });
 
-  ipcMain.handle('rewrite-selection', async (event, text) => {
-    try {
-      if (!text) return [];
-      const truncated = text.slice(0, 1000);
-      log(`Rewrite selection request length: ${text.length}`);
-      const apiKey = OPENAI_API_KEY;
-      if (!apiKey) {
-        log('OpenAI API key not set');
-        return { error: 'Missing OpenAI API key' };
-      }
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          model: OPENAI_MODEL,
-          messages: [
-            {
-              role: 'system',
-              content: REWRITE_PROMPT,
-            },
-            { role: 'user', content: truncated },
-          ],
-          n: 3,
-        }),
-        signal: event.signal,
-      });
-      if (!res.ok) {
-        error('Rewrite selection request failed:', res.statusText);
+  if (ENABLE_REWRITES) {
+    ipcMain.handle('rewrite-selection', async (event, text) => {
+      try {
+        if (!text) return [];
+        const truncated = text.slice(0, 1000);
+        log(`Rewrite selection request length: ${text.length}`);
+        const apiKey = OPENAI_API_KEY;
+        if (!apiKey) {
+          log('OpenAI API key not set');
+          return { error: 'Missing OpenAI API key' };
+        }
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${apiKey}`,
+          },
+          body: JSON.stringify({
+            model: OPENAI_MODEL,
+            messages: [
+              {
+                role: 'system',
+                content: REWRITE_PROMPT,
+              },
+              { role: 'user', content: truncated },
+            ],
+            n: 3,
+          }),
+          signal: event.signal,
+        });
+        if (!res.ok) {
+          error('Rewrite selection request failed:', res.statusText);
+          return { error: 'Request failed' };
+        }
+        const data = await res.json();
+        if (!data.choices) return { error: 'No suggestions' };
+        return data.choices
+          .map((c) => c.message?.content?.trim())
+          .filter(Boolean);
+      } catch (err) {
+        if (err.name === 'AbortError') {
+          log('Rewrite selection aborted');
+          return [];
+        }
+        error('Rewrite selection failed:', err);
         return { error: 'Request failed' };
       }
-      const data = await res.json();
-      if (!data.choices) return { error: 'No suggestions' };
-      return data.choices
-        .map((c) => c.message?.content?.trim())
-        .filter(Boolean);
-    } catch (err) {
-      if (err.name === 'AbortError') {
-        log('Rewrite selection aborted');
-        return [];
-      }
-      error('Rewrite selection failed:', err);
-      return { error: 'Request failed' };
-    }
-  });
+    });
+  }
 
   ipcMain.handle('check-for-updates', () => {
     if (!ENABLE_AUTO_UPDATES) {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -2,7 +2,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 console.log('[PRELOAD] Preload script loaded ✅');
 
-contextBridge.exposeInMainWorld('electronAPI', {
+const api = {
   // Prompter controls
   openPrompter: (html) => ipcRenderer.send('open-prompter', html),
   onScriptLoaded: (callback) => {
@@ -49,9 +49,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('save-script', { projectName, scriptName, html }),
   deleteScript: (projectName, scriptName) =>
     ipcRenderer.invoke('delete-script', projectName, scriptName),
-
-  rewriteSelection: (text, signal) =>
-    ipcRenderer.invoke('rewrite-selection', text, { signal }),
 
   onLogMessage: (callback) => {
     const handler = (_, msg) => callback(msg)
@@ -111,4 +108,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('update-downloaded', handler)
     return () => ipcRenderer.removeListener('update-downloaded', handler)
   },
-});
+};
+
+if (process.env.OPENAI_API_KEY) {
+  api.rewriteSelection = (text, signal) =>
+    ipcRenderer.invoke('rewrite-selection', text, { signal })
+}
+
+contextBridge.exposeInMainWorld('electronAPI', api);


### PR DESCRIPTION
## Summary
- load OpenAI API key from environment, .env file or config
- disable rewrite features when no key present
- document how to provide OPENAI_API_KEY for development and packaged builds

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a99e521c483218e26861ca18107f2