### PR TITLE
Handle missing project directories

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -68,6 +68,11 @@ const error = (...args) => {
   console.error(...args)
   sendLog(`[ERROR] ${msg}`)
 }
+const warn = (...args) => {
+  const msg = args.join(' ')
+  console.warn(...args)
+  sendLog(`[WARN] ${msg}`)
+}
 
 function sendUpdateStatus(data) {
   if (mainWindow && !mainWindow.isDestroyed()) {
@@ -879,7 +884,16 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
   ipcMain.handle('get-scripts-for-project', (_, projectName) => {
     log(`Fetching scripts for project: ${projectName}`);
     const folderPath = path.join(getProjectsPath(), projectName);
-    return fs.readdirSync(folderPath).filter((f) => f.endsWith('.docx'));
+    try {
+      if (!fs.existsSync(folderPath)) {
+        warn('Project folder not found:', folderPath);
+        return [];
+      }
+      return fs.readdirSync(folderPath).filter((f) => f.endsWith('.docx'));
+    } catch (err) {
+      warn('Failed to read project folder', folderPath, err);
+      return [];
+    }
   });
 
   ipcMain.handle('load-script', async (_, projectName, scriptName) => {


### PR DESCRIPTION
## Summary
- add warn logger
- safely handle missing project directories when listing scripts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a9f57eb1c832183229783149da782