### PR TITLE
Expose rewrite API unconditionally

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -9,7 +9,7 @@ const { spawn } = require('child_process');
 
 // OpenAI API key is provided at runtime via the OPENAI_API_KEY environment
 // variable. The key should never be committed to source control.
-const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+let OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 
 // Model and prompt configuration for AI rewrites
 const OPENAI_MODEL = 'gpt-4o';
@@ -407,9 +407,8 @@ async function createPrompterWindow() {
 // --- Electron App Lifecycle ---
 app.whenReady().then(async () => {
   OPENAI_API_KEY = loadOpenAIKey();
-  ENABLE_REWRITES = !!OPENAI_API_KEY;
-  if (!ENABLE_REWRITES) {
-    error('OpenAI API key not set. Rewrite features disabled.');
+  if (!OPENAI_API_KEY) {
+    error('OpenAI API key not set. Rewrite requests will fail.');
   }
   log('App ready');
   startViteServer();
@@ -510,51 +509,6 @@ app.whenReady().then(async () => {
     }
     log(`Prompter bounds set: ${JSON.stringify(bounds)}`);
   });
-
-  if (ENABLE_REWRITES) {
-    ipcMain.handle('rewrite-selection', async (_, text) => {
-      try {
-        if (!text) return [];
-        const truncated = text.slice(0, 1000);
-        log(`Rewrite selection request length: ${text.length}`);
-        const apiKey = OPENAI_API_KEY;
-        if (!apiKey) {
-          log('OpenAI API key not set');
-          return { error: 'Missing OpenAI API key' };
-        }
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify({
-            model: OPENAI_MODEL,
-            messages: [
-              {
-                role: 'system',
-                content: REWRITE_PROMPT,
-              },
-              { role: 'user', content: truncated },
-            ],
-            n: 3,
-          }),
-        });
-        if (!res.ok) {
-          error('Rewrite selection request failed:', res.statusText);
-          return { error: 'Request failed' };
-        }
-        const data = await res.json();
-        if (!data.choices) return { error: 'No suggestions' };
-        return data.choices
-          .map((c) => c.message?.content?.trim())
-          .filter(Boolean);
-      } catch (err) {
-        error('Rewrite selection failed:', err);
-        return { error: 'Request failed' };
-      }
-    });
-  }
 
   ipcMain.handle('get-all-projects-with-scripts', async () => {
     log('Fetching all projects with scripts');
@@ -1002,55 +956,53 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     }
   });
 
-  if (ENABLE_REWRITES) {
-    ipcMain.handle('rewrite-selection', async (event, text) => {
-      try {
-        if (!text) return [];
-        const truncated = text.slice(0, 1000);
-        log(`Rewrite selection request length: ${text.length}`);
-        const apiKey = OPENAI_API_KEY;
-        if (!apiKey) {
-          log('OpenAI API key not set');
-          return { error: 'Missing OpenAI API key' };
-        }
-        const res = await fetch('https://api.openai.com/v1/chat/completions', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify({
-            model: OPENAI_MODEL,
-            messages: [
-              {
-                role: 'system',
-                content: REWRITE_PROMPT,
-              },
-              { role: 'user', content: truncated },
-            ],
-            n: 3,
-          }),
-          signal: event.signal,
-        });
-        if (!res.ok) {
-          error('Rewrite selection request failed:', res.statusText);
-          return { error: 'Request failed' };
-        }
-        const data = await res.json();
-        if (!data.choices) return { error: 'No suggestions' };
-        return data.choices
-          .map((c) => c.message?.content?.trim())
-          .filter(Boolean);
-      } catch (err) {
-        if (err.name === 'AbortError') {
-          log('Rewrite selection aborted');
-          return [];
-        }
-        error('Rewrite selection failed:', err);
+  ipcMain.handle('rewrite-selection', async (event, text) => {
+    try {
+      if (!text) return [];
+      const truncated = text.slice(0, 1000);
+      log(`Rewrite selection request length: ${text.length}`);
+      const apiKey = OPENAI_API_KEY;
+      if (!apiKey) {
+        log('OpenAI API key not set');
+        return { error: 'Missing OpenAI API key' };
+      }
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: OPENAI_MODEL,
+          messages: [
+            {
+              role: 'system',
+              content: REWRITE_PROMPT,
+            },
+            { role: 'user', content: truncated },
+          ],
+          n: 3,
+        }),
+        signal: event.signal,
+      });
+      if (!res.ok) {
+        error('Rewrite selection request failed:', res.statusText);
         return { error: 'Request failed' };
       }
-    });
-  }
+      const data = await res.json();
+      if (!data.choices) return { error: 'No suggestions' };
+      return data.choices
+        .map((c) => c.message?.content?.trim())
+        .filter(Boolean);
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        log('Rewrite selection aborted');
+        return [];
+      }
+      error('Rewrite selection failed:', err);
+      return { error: 'Request failed' };
+    }
+  });
 
   ipcMain.handle('check-for-updates', () => {
     if (!ENABLE_AUTO_UPDATES) {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -110,9 +110,7 @@ const api = {
   },
 };
 
-if (process.env.OPENAI_API_KEY) {
-  api.rewriteSelection = (text, signal) =>
-    ipcRenderer.invoke('rewrite-selection', text, { signal })
-}
+api.rewriteSelection = (text, signal) =>
+  ipcRenderer.invoke('rewrite-selection', text, { signal })
 
 contextBridge.exposeInMainWorld('electronAPI', api);


### PR DESCRIPTION
## Summary
- Always expose `api.rewriteSelection` to the renderer
- Handle `rewrite-selection` requests in the main process even without an API key

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a9f63ca4c8321965d0ff4627ebdd3