### PR TITLE
refactor: update rewrite prompt and parsing

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -131,7 +131,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     window.electronAPI
       .rewriteSelection(selectedText, ctrl.signal)
       .then((res) => {
-        if (!Array.isArray(res) || res.length === 0) {
+        if (!Array.isArray(res) || res.length !== 3) {
           setError(true)
           setSuggestions(['No suggestions available'])
         } else {


### PR DESCRIPTION
## Summary
- revise REWRITE_PROMPT to produce three teleprompter-ready alternatives in JSON
- request JSON responses and parse them to ensure exactly three suggestions
- validate suggestion array length in the editor before displaying

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/rename-script.test.cjs`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689aa2f66f8083219921e96699681166