### PR TITLE
refactor: update rewrite prompt and parsing

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -14,19 +14,18 @@ let OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
 // Model and prompt configuration for AI rewrites
 const OPENAI_MODEL = 'gpt-4o';
 
-const REWRITE_PROMPT = `You are an expert copywriter and orator.
+const REWRITE_PROMPT = `You punch up lines for spoken delivery.
 
-Rewrite the provided text in three distinct ways, each preserving the original meaning but offering:
+Given the input text, produce three alternative phrasings suitable for a teleprompter reader.
+Constraints:
+- Preserve meaning, tense, and point of view.
+- Keep proper nouns and numbers exactly as written.
+- Keep roughly the same length (+/− 15%).
+- Natural spoken cadence; avoid jargon and filler.
+- No preambles, no labels, no explanations.
 
-1. **Impact** – Stronger, more engaging wording.
-2. **Clarity** – Simpler, more direct wording.
-3. **Altered Tone** – A different emotional feel (e.g., more tense, humorous, or dramatic, as fits the context).
-
-Requirements:
-- Keep each rewrite roughly the same length as the original.
-- Do not add or remove information.
-- Do not change proper nouns.
-- Label each version clearly as "Impact:", "Clarity:", and "Altered Tone:".`;
+Return ONLY valid JSON with this shape:
+{"suggestions": ["string1", "string2", "string3"]}`;
 
 module.exports = { OPENAI_MODEL, REWRITE_PROMPT };
 
@@ -988,6 +987,7 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
         },
         body: JSON.stringify({
           model: OPENAI_MODEL,
+          response_format: { type: 'json_object' },
           messages: [
             {
               role: 'system',
@@ -995,7 +995,6 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
             },
             { role: 'user', content: truncated },
           ],
-          n: 3,
         }),
         signal: event.signal,
       });
@@ -1004,10 +1003,25 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
         return { error: 'Request failed' };
       }
       const data = await res.json();
-      if (!data.choices) return { error: 'No suggestions' };
-      return data.choices
-        .map((c) => c.message?.content?.trim())
-        .filter(Boolean);
+      const content = data.choices?.[0]?.message?.content?.trim();
+      if (!content) return { error: 'No suggestions' };
+      try {
+        const parsed = JSON.parse(content);
+        const suggestions = Array.isArray(parsed)
+          ? parsed
+          : parsed.suggestions;
+        if (
+          !Array.isArray(suggestions) ||
+          suggestions.length !== 3 ||
+          !suggestions.every((s) => typeof s === 'string')
+        ) {
+          throw new Error('Expected array of 3 strings');
+        }
+        return suggestions;
+      } catch (err) {
+        error('Failed to parse suggestions:', err);
+        return { error: 'Invalid response format' };
+      }
     } catch (err) {
       if (err.name === 'AbortError') {
         log('Rewrite selection aborted');

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -131,7 +131,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     window.electronAPI
       .rewriteSelection(selectedText, ctrl.signal)
       .then((res) => {
-        if (!Array.isArray(res) || res.length === 0) {
+        if (!Array.isArray(res) || res.length !== 3) {
           setError(true)
           setSuggestions(['No suggestions available'])
         } else {


### PR DESCRIPTION
## Summary
- revise REWRITE_PROMPT to specify suggestions array inside a JSON object
- parse OpenAI responses from either array or object and validate exactly three string suggestions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node tests/rename-script.test.cjs`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689aa2f66f8083219921e96699681166