### PR TITLE
Handle OpenAI rate limits in rewrite-selection

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -131,7 +131,10 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     window.electronAPI
       .rewriteSelection(selectedText, ctrl.signal)
       .then((res) => {
-        if (!Array.isArray(res) || res.length !== 3) {
+        if (res?.error === 'Rate limit exceeded') {
+          setError(true)
+          setSuggestions(['Rate limit exceeded'])
+        } else if (!Array.isArray(res) || res.length !== 3) {
           setError(true)
           setSuggestions(['No suggestions available'])
         } else {


### PR DESCRIPTION
## Summary
- handle 429 responses from the OpenAI rewrite-selection endpoint with retries and a rate limit error
- surface rate limit errors in the renderer so users see "Rate limit exceeded"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b4fd2ea54832182f2fbb1a9440743