### PR TITLE
feat: support abort signal for rewrite selection

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -969,7 +969,7 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     }
   });
 
-  ipcMain.handle('rewrite-selection', async (event, text) => {
+  ipcMain.handle('rewrite-selection', async (event, text, { signal }) => {
     try {
       if (!text) return [];
       const truncated = text.slice(0, 1000);
@@ -998,7 +998,7 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
               { role: 'user', content: truncated },
             ],
           }),
-          signal: event.signal,
+          signal,
         });
         if (res.status === 429) {
           const delay = 500 * 2 ** attempt;


### PR DESCRIPTION
## Summary
- accept AbortController signal in `rewrite-selection` handler
- forward signal to fetch request for OpenAI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'setError' is not defined)*
- `npx eslint electron/main.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689b552d6d908321bf2d92cedb8e82bb