### PR TITLE
Refactor rewrite cancellation mechanism

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,4 +1,5 @@
 const { contextBridge, ipcRenderer } = require('electron');
+const { randomUUID } = require('crypto');
 
 console.log('[PRELOAD] Preload script loaded ✅');
 
@@ -110,7 +111,12 @@ const api = {
   },
 };
 
-api.rewriteSelection = (text, signal) =>
-  ipcRenderer.invoke('rewrite-selection', text, { signal })
+api.rewriteSelection = (text) => {
+  const id = randomUUID();
+  const promise = ipcRenderer.invoke('rewrite-selection', id, text);
+  return { id, promise };
+};
+
+api.abortRewrite = (id) => ipcRenderer.send('rewrite-selection-abort', id);
 
 contextBridge.exposeInMainWorld('electronAPI', api);


### PR DESCRIPTION
## Summary
- switch TipTapEditor to use rewrite requests with IDs and abortRewrite instead of forwarding AbortSignals
- generate request IDs in preload and expose abortRewrite IPC helper
- manage AbortControllers per rewrite request in main process, aborting via request IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b58fe3bb883219bede7f0b1e736b2