### PR TITLE
refactor: resolve log path without app

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -3,6 +3,7 @@ const { autoUpdater } = require('electron-updater');
 const http = require('http');
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 const mammoth = require('mammoth');
 const htmlToDocx = require('html-to-docx');
 const { spawn } = require('child_process');
@@ -50,8 +51,8 @@ let isAlwaysOnTop = false;
 let currentScriptHtml = '';
 const rewriteControllers = new Map();
 
-const logDir = path.join(app.getPath('home'), 'leaderprompt', 'logs');
-if (!fs.existsSync(logDir)) fs.mkdirSync(logDir, { recursive: true });
+const logDir = path.join(os.homedir(), 'leaderprompt', 'logs');
+fs.mkdirSync(logDir, { recursive: true });
 const logFilePath = path.join(
   logDir,
   `leaderprompt-${new Date().toISOString().replace(/[:.]/g, '-')}.log`,


### PR DESCRIPTION
## Summary
- resolve log directory with `os.homedir()`
- ensure log folder creation before writing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b71f19090832192dbfeabb663cfde