### PR TITLE
Guard renderer components against missing electronAPI

### DIFF
--- a/src/DevConsole.jsx
+++ b/src/DevConsole.jsx
@@ -8,6 +8,10 @@ function DevConsole() {
     const handler = (msg) => {
       setLogs((prev) => [...prev, msg])
     }
+    if (!window.electronAPI?.onLogMessage) {
+      console.error('electronAPI unavailable')
+      return
+    }
     const cleanup = window.electronAPI.onLogMessage(handler)
     return () => {
       cleanup?.()

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -95,6 +95,10 @@ const FileManager = forwardRef(function FileManager({
   }, []);
 
   const loadProjects = async () => {
+    if (!window.electronAPI?.getAllProjectsWithScripts) {
+      console.error('electronAPI unavailable');
+      return;
+    }
     const result = await window.electronAPI.getAllProjectsWithScripts();
     if (result) {
       setProjects(result);
@@ -113,6 +117,10 @@ const FileManager = forwardRef(function FileManager({
   const handleNewProject = async () => {
     if (!newProjectName.trim()) return;
 
+    if (!window.electronAPI?.createNewProject) {
+      console.error('electronAPI unavailable');
+      return;
+    }
     const created = await window.electronAPI.createNewProject(newProjectName.trim());
     if (created) {
       setNewProjectName('');
@@ -126,6 +134,10 @@ const FileManager = forwardRef(function FileManager({
   };
 
   const handleImportClick = async (projectName) => {
+    if (!window.electronAPI?.selectFiles || !window.electronAPI?.importScriptsToProject) {
+      console.error('electronAPI unavailable');
+      return;
+    }
     const filePaths = await window.electronAPI.selectFiles();
     if (!filePaths) return;
 
@@ -136,6 +148,10 @@ const FileManager = forwardRef(function FileManager({
 
   const handleNewScript = async () => {
     const projectName = 'Quick Scripts';
+    if (!window.electronAPI?.createNewScript) {
+      console.error('electronAPI unavailable');
+      return;
+    }
     const result = await window.electronAPI.createNewScript(projectName, 'New Script');
     if (result && result.success) {
       await loadProjects();
@@ -170,6 +186,12 @@ const FileManager = forwardRef(function FileManager({
 
   const confirmRenameProject = async (oldName) => {
     if (!renameValue.trim()) return;
+    if (!window.electronAPI?.renameProject) {
+      console.error('electronAPI unavailable');
+      toast.error('Failed to rename project');
+      cancelRename();
+      return;
+    }
     const success = await window.electronAPI.renameProject(
       oldName,
       renameValue.trim(),
@@ -189,6 +211,12 @@ const FileManager = forwardRef(function FileManager({
     let newName = renameValue.trim();
     if (!newName.toLowerCase().endsWith('.docx')) {
       newName += '.docx';
+    }
+    if (!window.electronAPI?.renameScript) {
+      console.error('electronAPI unavailable');
+      toast.error('Failed to rename script');
+      cancelRename();
+      return;
     }
     const success = await window.electronAPI.renameScript(
       projectName,
@@ -214,6 +242,11 @@ const FileManager = forwardRef(function FileManager({
     openConfirm(
       `Delete project "${projectName}"? This will remove all its scripts.`,
       async () => {
+        if (!window.electronAPI?.deleteProject) {
+          console.error('electronAPI unavailable');
+          toast.error('Failed to delete project');
+          return;
+        }
         const deleted = await window.electronAPI.deleteProject(projectName);
         if (!deleted) {
           console.error('Failed to delete project');
@@ -230,6 +263,11 @@ const FileManager = forwardRef(function FileManager({
     openConfirm(
       `Delete script "${scriptName}" from "${projectName}"?`,
       async () => {
+        if (!window.electronAPI?.deleteScript) {
+          console.error('electronAPI unavailable');
+          toast.error('Failed to delete script');
+          return;
+        }
         const deleted = await window.electronAPI.deleteScript(projectName, scriptName);
         if (!deleted) {
           console.error('Failed to delete script');
@@ -312,6 +350,10 @@ const FileManager = forwardRef(function FileManager({
     setRootDrag(false);
     const paths = Array.from(e.dataTransfer.files || []).map((f) => f.path);
     if (paths.length) {
+      if (!window.electronAPI?.importFoldersAsProjects) {
+        console.error('electronAPI unavailable');
+        return;
+      }
       await window.electronAPI.importFoldersAsProjects(paths);
       await loadProjects();
       toast.success('Projects imported');
@@ -324,6 +366,10 @@ const FileManager = forwardRef(function FileManager({
     const external = e.dataTransfer.files && e.dataTransfer.files.length;
     if (external && !dragInfo) {
       const filePaths = Array.from(e.dataTransfer.files).map((f) => f.path);
+      if (!window.electronAPI?.importScriptsToProject) {
+        console.error('electronAPI unavailable');
+        return;
+      }
       await window.electronAPI.importScriptsToProject(filePaths, projectName);
       await loadProjects();
       toast.success('Scripts imported');
@@ -347,6 +393,10 @@ const FileManager = forwardRef(function FileManager({
       );
       setDragInfo(null);
       if (newOrder) {
+        if (!window.electronAPI?.reorderScripts) {
+          console.error('electronAPI unavailable');
+          return;
+        }
         await window.electronAPI.reorderScripts(projectName, newOrder);
       }
     } else {
@@ -364,6 +414,10 @@ const FileManager = forwardRef(function FileManager({
       if (index < 0 || index > destOrder.length) destOrder.push(scriptName);
       else destOrder.splice(index, 0, scriptName);
       setDragInfo(null);
+      if (!window.electronAPI?.moveScript || !window.electronAPI?.reorderScripts) {
+        console.error('electronAPI unavailable');
+        return;
+      }
       await window.electronAPI.moveScript(
         sourceProject,
         projectName,

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -51,6 +51,10 @@ function Prompter() {
 
   const handleEdit = (html) => {
     setContent(html)
+    if (!window.electronAPI?.sendUpdatedScript) {
+      console.error('electronAPI unavailable')
+      return
+    }
     window.electronAPI.sendUpdatedScript(html)
   }
 
@@ -135,6 +139,13 @@ function Prompter() {
     e.preventDefault()
     const startX = e.screenX
     const startY = e.screenY
+    if (
+      !window.electronAPI?.getPrompterBounds ||
+      !window.electronAPI?.setPrompterBounds
+    ) {
+      console.error('electronAPI unavailable')
+      return
+    }
     const bounds = await window.electronAPI.getPrompterBounds()
 
     const onMove = (ev) => {
@@ -153,6 +164,10 @@ function Prompter() {
         newBounds.y = bounds.y + dy
       }
 
+      if (!window.electronAPI?.setPrompterBounds) {
+        console.error('electronAPI unavailable')
+        return
+      }
       window.electronAPI.setPrompterBounds(newBounds)
     }
 
@@ -172,6 +187,15 @@ function Prompter() {
     }
     const handleUpdated = (html) => {
       setContent(html)
+    }
+
+    if (
+      !window.electronAPI?.onScriptLoaded ||
+      !window.electronAPI?.onScriptUpdated ||
+      !window.electronAPI?.getCurrentScript
+    ) {
+      console.error('electronAPI unavailable')
+      return
     }
 
     const cleanupLoaded = window.electronAPI.onScriptLoaded(handleLoaded)
@@ -261,6 +285,10 @@ function Prompter() {
   useEffect(() => {
     if (!mountedRef.current) {
       mountedRef.current = true
+      if (!window.electronAPI?.prompterReady) {
+        console.error('electronAPI unavailable')
+        return
+      }
       window.electronAPI.prompterReady()
     }
   }, [])
@@ -285,7 +313,13 @@ function Prompter() {
         <div className={`main-settings ${mainSettingsOpen ? 'open' : ''}`}>
         <button
           className="stop-button"
-          onClick={() => window.electronAPI.closePrompter()}
+          onClick={() => {
+            if (!window.electronAPI?.closePrompter) {
+              console.error('electronAPI unavailable')
+              return
+            }
+            window.electronAPI.closePrompter()
+          }}
         >
           Stop Prompting
         </button>

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -124,7 +124,13 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   }, [activeMenu, editor, selectedText, retryCount, menuPos])
 
   useEffect(() => {
-    if (!window.electronAPI?.rewriteSelection) return
+    if (
+      !window.electronAPI?.rewriteSelection ||
+      !window.electronAPI?.abortRewrite
+    ) {
+      console.error('electronAPI unavailable')
+      return
+    }
     if (activeMenu !== 'ai' || !selectedText.trim() || menuPos === null) return
     setErrorMessage(null)
     const { id, promise } = window.electronAPI.rewriteSelection(selectedText)
@@ -156,12 +162,24 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
         clearInterval(loaderRef.current)
         loaderRef.current = null
       })
-    return () => window.electronAPI.abortRewrite(id)
+    return () => {
+      if (!window.electronAPI?.abortRewrite) {
+        console.error('electronAPI unavailable')
+        return
+      }
+      window.electronAPI.abortRewrite(id)
+    }
   }, [activeMenu, selectedText, retryCount, menuPos])
 
   useEffect(() => {
     if (activeMenu === 'ai' && menuPos !== null) return
-    if (rewriteId) window.electronAPI.abortRewrite(rewriteId)
+    if (rewriteId) {
+      if (!window.electronAPI?.abortRewrite) {
+        console.error('electronAPI unavailable')
+        return
+      }
+      window.electronAPI.abortRewrite(rewriteId)
+    }
   }, [activeMenu, menuPos, rewriteId])
 
   useEffect(() => {

--- a/src/Updater.jsx
+++ b/src/Updater.jsx
@@ -3,6 +3,19 @@ import { toast } from 'react-hot-toast'
 
 function Updater() {
   useEffect(() => {
+    if (
+      !window.electronAPI?.checkForUpdates ||
+      !window.electronAPI?.onUpdateChecking ||
+      !window.electronAPI?.onUpdateAvailable ||
+      !window.electronAPI?.onUpdateNotAvailable ||
+      !window.electronAPI?.onUpdateError ||
+      !window.electronAPI?.onUpdateProgress ||
+      !window.electronAPI?.onUpdateDownloaded ||
+      !window.electronAPI?.restartAndInstall
+    ) {
+      console.error('electronAPI unavailable')
+      return
+    }
     window.electronAPI.checkForUpdates()
 
     const cleanChecking = window.electronAPI.onUpdateChecking(() => {
@@ -35,7 +48,7 @@ function Updater() {
       toast((t) => (
         <span>
           Update ready.
-          <button onClick={() => { window.electronAPI.restartAndInstall(); toast.dismiss(t.id) }}>Restart</button>
+          <button onClick={() => { if (!window.electronAPI?.restartAndInstall) { console.error('electronAPI unavailable'); return } window.electronAPI.restartAndInstall(); toast.dismiss(t.id) }}>Restart</button>
         </span>
       ), { duration: Infinity })
     })

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -34,7 +34,13 @@ createRoot(document.getElementById('root')).render(
       </Routes>
       <button
         className="dev-console-button"
-        onClick={() => window.electronAPI.openDevConsole()}
+        onClick={() => {
+          if (!window.electronAPI?.openDevConsole) {
+            console.error('electronAPI unavailable')
+            return
+          }
+          window.electronAPI.openDevConsole()
+        }}
       >
         <DevIcon />
       </button>


### PR DESCRIPTION
## Summary
- add defensive checks before calling `window.electronAPI` methods in renderer components
- prevent runtime errors when electron APIs are unavailable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b7640b3b883218dfc513ecb57a836