### PR TITLE
feat: use browser randomUUID in preload script

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,7 +1,12 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const { randomUUID } = require('crypto');
-
 console.log('[PRELOAD] Preload script loaded ✅');
+
+const randomUUID = () => {
+  if (window?.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
 
 const api = {
   // Prompter controls


### PR DESCRIPTION
## Summary
- remove Node `crypto` dependency from preload
- use `window.crypto.randomUUID()` to generate request IDs

## Testing
- `npm run lint`
- `npm run build`
- `xvfb-run -a npm run electron-dev` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ce7bdd08321a61b18a793115390