### PR TITLE
Stabilize ScriptViewer callbacks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,20 +28,23 @@ function App() {
     setSelectedScript(scriptName);
   };
 
-  const handlePrompterOpen = (projectName, scriptName) => {
-    setLoadedProject(projectName);
-    setLoadedScript(scriptName);
-  };
+  const handlePrompterOpen = useCallback(
+    (projectName, scriptName) => {
+      setLoadedProject(projectName);
+      setLoadedScript(scriptName);
+    },
+    [setLoadedProject, setLoadedScript],
+  );
 
-  const handlePrompterClose = () => {
+  const handlePrompterClose = useCallback(() => {
     setLoadedProject(null);
     setLoadedScript(null);
-  };
+  }, [setLoadedProject, setLoadedScript]);
 
-  const handleViewerClose = () => {
+  const handleViewerClose = useCallback(() => {
     setSelectedProject(null);
     setSelectedScript(null);
-  };
+  }, [setSelectedProject, setSelectedScript]);
 
   const updateCloseCallback = useCallback((cb) => {
     setCloseCallback(() => cb);


### PR DESCRIPTION
## Summary
- Memoize ScriptViewer callbacks with `useCallback` to avoid identity changes and update loops

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689b88e4c93c8321a6d9128b0ebac0f1