### PR TITLE
style: center ScriptViewer heading

### DIFF
--- a/src/ScriptViewer.css
+++ b/src/ScriptViewer.css
@@ -13,7 +13,7 @@
 .viewer-header {
   display: flex;
   width: 100%;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   margin-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- center the script viewer header by updating its flex alignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689b9565f6c08321bac5e25abe0f2e00