### PR TITLE
Fix right panel overflow handling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -38,8 +38,7 @@ body {
   flex-direction: column;
   align-items: stretch;
   padding: 2vw 2vw 0;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- prevent `.right-panel` from scrolling by using `overflow: hidden`
- confirm script viewer content still scrolls

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b96c23d748321b0204af18b78c525