### PR TITLE
Add style modifier option for AI rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ windows. This avoids reload loops while Vite is starting.
 
 LeaderPrompt can suggest alternative phrasings for selected text using OpenAI's
 API. The feature looks for an API key at startup and disables itself if none is
-available.
+available. The rewrite panel also supports an optional style modifier: click
+**Add style** to reveal a text field where you can describe the desired tone
+(for example, "formal" or "playful"). The modifier is sent with rewrite
+requests to the model.
 
 ### Local development
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -975,12 +975,13 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     }
   });
 
-  ipcMain.handle('rewrite-selection', async (event, id, text) => {
+  ipcMain.handle('rewrite-selection', async (event, id, text, modifier) => {
     const controller = new AbortController();
     rewriteControllers.set(id, controller);
     try {
       if (!text) return [];
       const truncated = text.slice(0, 1000);
+      const style = typeof modifier === 'string' ? modifier.trim() : '';
       log(`Rewrite selection request length: ${text.length}`);
       const apiKey = OPENAI_API_KEY;
       if (!apiKey) {
@@ -997,10 +998,10 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
           model: OPENAI_MODEL,
           response_format: { type: 'json_object' },
           messages: [
-            {
-              role: 'system',
-              content: REWRITE_PROMPT,
-            },
+            { role: 'system', content: REWRITE_PROMPT },
+            ...(style
+              ? [{ role: 'system', content: `Rewrite the text to sound ${style}.` }]
+              : []),
             { role: 'user', content: truncated },
           ],
         }),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -116,9 +116,9 @@ const api = {
   },
 };
 
-api.rewriteSelection = (text) => {
+api.rewriteSelection = (text, modifier) => {
   const id = randomUUID();
-  const promise = ipcRenderer.invoke('rewrite-selection', id, text);
+  const promise = ipcRenderer.invoke('rewrite-selection', id, text, modifier);
   return { id, promise };
 };
 

--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -90,6 +90,29 @@
   background: #555;
 }
 
+.ai-rescript-panel .modifier-btn {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  color: #89c4ff;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 4px 8px;
+}
+
+.ai-rescript-panel .modifier-btn:hover {
+  color: #cde2ff;
+}
+
+.ai-rescript-panel .modifier-input {
+  margin: 4px 8px;
+  padding: 4px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #222;
+  color: #e0e0e0;
+}
+
 .ai-line {
   padding: 6px 8px;
   cursor: pointer;

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -27,6 +27,8 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   const [errorMessage, setErrorMessage] = useState(null)
   const loaderRef = useRef(null)
   const [isOnline, setIsOnline] = useState(navigator.onLine)
+  const [modifier, setModifier] = useState('')
+  const [isModifierInputVisible, setModifierInputVisible] = useState(false)
 
   const openMenu = (pos) => {
     setMenuPos(pos)
@@ -109,7 +111,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     }
   }
 
-  const runRewrite = (textArg) => {
+  const runRewrite = (textArg, modifierArg = modifier) => {
     if (
       !editor ||
       !window.electronAPI?.rewriteSelection ||
@@ -148,7 +150,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     }, 150)
 
     setErrorMessage(null)
-    const { id, promise } = window.electronAPI.rewriteSelection(text)
+    const { id, promise } = window.electronAPI.rewriteSelection(text, modifierArg)
     rewriteIdRef.current = id
     promise
       .then((res) => {
@@ -354,6 +356,23 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
           {activeMenu === 'ai' && (
             <div className="ai-rescript-panel fade-in">
               <button className="back-btn" onClick={goBack}>←</button>
+              {!isModifierInputVisible && (
+                <button
+                  className="modifier-btn"
+                  onClick={() => setModifierInputVisible(true)}
+                >
+                  Add style
+                </button>
+              )}
+              {isModifierInputVisible && (
+                <input
+                  className="modifier-input"
+                  type="text"
+                  placeholder="e.g. formal, playful"
+                  value={modifier}
+                  onChange={(e) => setModifier(e.target.value)}
+                />
+              )}
               {suggestions.map((result, i) => (
                 <div
                   key={i}

--- a/tests/manual-qa.md
+++ b/tests/manual-qa.md
@@ -1,0 +1,9 @@
+# Manual QA
+
+## Modifier-based rewrites
+
+1. Select a portion of text in the editor.
+2. Open the context menu and choose **AI Rewrites**.
+3. Click **Add style** and enter a modifier such as `formal`.
+4. Trigger a rewrite (initial suggestions or by using **Retry**).
+5. Confirm the returned suggestions reflect the chosen modifier.

--- a/tests/rewrite-selection-bridge.test.cjs
+++ b/tests/rewrite-selection-bridge.test.cjs
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const Module = require('module');
+
+// Helper to load preload with mocked electron module
+function loadPreload() {
+  let exposed;
+  const ipcRenderer = {
+    invoke: (...args) => {
+      loadPreload.invokeArgs = args;
+      return Promise.resolve();
+    },
+    on: () => {},
+    send: () => {},
+  };
+  const contextBridge = {
+    exposeInMainWorld: (key, api) => {
+      exposed = api;
+    },
+  };
+  const electronPath = require.resolve('electron');
+  const original = Module._cache[electronPath];
+  Module._cache[electronPath] = { exports: { ipcRenderer, contextBridge } };
+  delete require.cache[require.resolve('../electron/preload.cjs')];
+  global.window = {};
+  require('../electron/preload.cjs');
+  if (original) {
+    Module._cache[electronPath] = original;
+  } else {
+    delete Module._cache[electronPath];
+  }
+  return exposed;
+}
+
+test('rewriteSelection forwards modifier', () => {
+  const api = loadPreload();
+  api.rewriteSelection('hello', 'formal');
+  const args = loadPreload.invokeArgs;
+  assert.strictEqual(args[0], 'rewrite-selection');
+  assert.strictEqual(args[2], 'hello');
+  assert.strictEqual(args[3], 'formal');
+  assert.strictEqual(typeof args[1], 'string');
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- allow entering an optional style modifier in the AI rewrite panel
- plumb modifier through preload and main processes
- document modifier option and add bridge test & manual QA instructions

## Testing
- `node --test tests/rewrite-selection-bridge.test.cjs tests/rename-script.test.cjs`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689b9a07cfec8321a79abbc60d4e7b3b