### PR TITLE
Add style modifier option for AI rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ windows. This avoids reload loops while Vite is starting.
 
 LeaderPrompt can suggest alternative phrasings for selected text using OpenAI's
 API. The feature looks for an API key at startup and disables itself if none is
-available.
+available. The rewrite panel also supports an optional style modifier: click
+**Add style** to reveal a text field where you can describe the desired tone
+(for example, "formal" or "playful"). The modifier is sent with rewrite
+requests to the model. Use the ↻ button to re-run a request if you want a fresh
+set of suggestions.
 
 ### Local development
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -975,12 +975,13 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
     }
   });
 
-  ipcMain.handle('rewrite-selection', async (event, id, text) => {
+  ipcMain.handle('rewrite-selection', async (event, id, text, modifier) => {
     const controller = new AbortController();
     rewriteControllers.set(id, controller);
     try {
       if (!text) return [];
       const truncated = text.slice(0, 1000);
+      const style = typeof modifier === 'string' ? modifier.trim() : '';
       log(`Rewrite selection request length: ${text.length}`);
       const apiKey = OPENAI_API_KEY;
       if (!apiKey) {
@@ -997,10 +998,10 @@ ipcMain.handle('import-folders-as-projects', async (_, folderPaths) => {
           model: OPENAI_MODEL,
           response_format: { type: 'json_object' },
           messages: [
-            {
-              role: 'system',
-              content: REWRITE_PROMPT,
-            },
+            { role: 'system', content: REWRITE_PROMPT },
+            ...(style
+              ? [{ role: 'system', content: `Rewrite the text to sound ${style}.` }]
+              : []),
             { role: 'user', content: truncated },
           ],
         }),

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -116,9 +116,9 @@ const api = {
   },
 };
 
-api.rewriteSelection = (text) => {
+api.rewriteSelection = (text, modifier) => {
   const id = randomUUID();
-  const promise = ipcRenderer.invoke('rewrite-selection', id, text);
+  const promise = ipcRenderer.invoke('rewrite-selection', id, text, modifier);
   return { id, promise };
 };
 

--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -77,6 +77,18 @@
   flex-direction: column;
 }
 
+.ai-rescript-panel .ai-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ai-rescript-panel .ai-header-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .ai-rescript-panel .back-btn {
   align-self: flex-start;
   background: transparent;
@@ -88,6 +100,41 @@
 
 .ai-rescript-panel .back-btn:hover {
   background: #555;
+}
+
+.ai-rescript-panel .modifier-btn {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  color: #89c4ff;
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 4px 8px;
+}
+
+.ai-rescript-panel .modifier-btn:hover {
+  color: #cde2ff;
+}
+
+.ai-rescript-panel .rerun-btn {
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.ai-rescript-panel .rerun-btn:hover {
+  background: #555;
+}
+
+.ai-rescript-panel .modifier-input {
+  margin: 4px 8px;
+  padding: 4px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background: #222;
+  color: #e0e0e0;
 }
 
 .ai-line {

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -27,6 +27,8 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
   const [errorMessage, setErrorMessage] = useState(null)
   const loaderRef = useRef(null)
   const [isOnline, setIsOnline] = useState(navigator.onLine)
+  const [modifier, setModifier] = useState('')
+  const [isModifierInputVisible, setModifierInputVisible] = useState(false)
 
   const openMenu = (pos) => {
     setMenuPos(pos)
@@ -109,7 +111,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     }
   }
 
-  const runRewrite = (textArg) => {
+  const runRewrite = (textArg, modifierArg = modifier) => {
     if (
       !editor ||
       !window.electronAPI?.rewriteSelection ||
@@ -148,7 +150,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
     }, 150)
 
     setErrorMessage(null)
-    const { id, promise } = window.electronAPI.rewriteSelection(text)
+    const { id, promise } = window.electronAPI.rewriteSelection(text, modifierArg)
     rewriteIdRef.current = id
     promise
       .then((res) => {
@@ -353,7 +355,35 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
           )}
           {activeMenu === 'ai' && (
             <div className="ai-rescript-panel fade-in">
-              <button className="back-btn" onClick={goBack}>←</button>
+              <div className="ai-header">
+                <button className="back-btn" onClick={goBack}>←</button>
+                <div className="ai-header-right">
+                  {!isModifierInputVisible && (
+                    <button
+                      className="modifier-btn"
+                      onClick={() => setModifierInputVisible(true)}
+                    >
+                      Add style
+                    </button>
+                  )}
+                  <button
+                    className="rerun-btn"
+                    onClick={() => runRewrite(selectedText)}
+                    title="Run again"
+                  >
+                    ↻
+                  </button>
+                </div>
+              </div>
+              {isModifierInputVisible && (
+                <input
+                  className="modifier-input"
+                  type="text"
+                  placeholder="e.g. formal, playful"
+                  value={modifier}
+                  onChange={(e) => setModifier(e.target.value)}
+                />
+              )}
               {suggestions.map((result, i) => (
                 <div
                   key={i}

--- a/tests/manual-qa.md
+++ b/tests/manual-qa.md
@@ -1,0 +1,10 @@
+# Manual QA
+
+## Modifier-based rewrites
+
+1. Select a portion of text in the editor.
+2. Open the context menu and choose **AI Rewrites**.
+3. Click **Add style** and enter a modifier such as `formal`.
+4. Trigger a rewrite (initial suggestions or by using **Retry**).
+5. Click the ↻ button to re-run the request.
+6. Confirm the returned suggestions reflect the chosen modifier on each run.

--- a/tests/rewrite-selection-bridge.test.cjs
+++ b/tests/rewrite-selection-bridge.test.cjs
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const Module = require('module');
+
+// Helper to load preload with mocked electron module
+function loadPreload() {
+  let exposed;
+  const ipcRenderer = {
+    invoke: (...args) => {
+      loadPreload.invokeArgs = args;
+      return Promise.resolve();
+    },
+    on: () => {},
+    send: () => {},
+  };
+  const contextBridge = {
+    exposeInMainWorld: (key, api) => {
+      exposed = api;
+    },
+  };
+  const electronPath = require.resolve('electron');
+  const original = Module._cache[electronPath];
+  Module._cache[electronPath] = { exports: { ipcRenderer, contextBridge } };
+  delete require.cache[require.resolve('../electron/preload.cjs')];
+  global.window = {};
+  require('../electron/preload.cjs');
+  if (original) {
+    Module._cache[electronPath] = original;
+  } else {
+    delete Module._cache[electronPath];
+  }
+  return exposed;
+}
+
+test('rewriteSelection forwards modifier', () => {
+  const api = loadPreload();
+  api.rewriteSelection('hello', 'formal');
+  const args = loadPreload.invokeArgs;
+  assert.strictEqual(args[0], 'rewrite-selection');
+  assert.strictEqual(args[2], 'hello');
+  assert.strictEqual(args[3], 'formal');
+  assert.strictEqual(typeof args[1], 'string');
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- allow entering an optional style modifier in the AI rewrite panel
- plumb modifier through preload and main processes
- document modifier option and add bridge test & manual QA instructions
- add rerun button so users can refresh suggestions with the current modifier

## Testing
- `npm run lint`
- `node --test tests/rewrite-selection-bridge.test.cjs tests/rename-script.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_689b9a07cfec8321a79abbc60d4e7b3b