### PR TITLE
Add read page with hero section and issue preview carousel

### DIFF
--- a/src/ReadPage.jsx
+++ b/src/ReadPage.jsx
@@ -1,0 +1,13 @@
+import HeroSection from './components/HeroSection';
+import PreviewCarousel from './components/PreviewCarousel';
+
+const ReadPage = () => {
+  return (
+    <div>
+      <HeroSection />
+      <PreviewCarousel />
+    </div>
+  );
+};
+
+export default ReadPage;

--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -1,0 +1,36 @@
+.hero-section {
+  position: relative;
+  width: 100%;
+}
+
+.hero-image {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.hero-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.4);
+  padding: 1rem;
+}
+
+.hero-cta {
+  margin-top: 1rem;
+  padding: 0.75rem 1.5rem;
+  background-color: #ffcc00;
+  color: #000;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+}

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -1,0 +1,25 @@
+import './HeroSection.css';
+import { issues } from '../data/issues';
+
+const HeroSection = () => {
+  const firstIssue = issues[0];
+  return (
+    <section className="hero-section">
+      <img src={firstIssue.cover} alt={firstIssue.title} className="hero-image" />
+      <div className="hero-overlay">
+        <h1>A slow-burn supernatural mystery set in 1920s Colorado.</h1>
+        <p>Start reading. Start unraveling.</p>
+        <a
+          href={firstIssue.readerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hero-cta"
+        >
+          Read Now
+        </a>
+      </div>
+    </section>
+  );
+};
+
+export default HeroSection;

--- a/src/components/InfoPanel.css
+++ b/src/components/InfoPanel.css
@@ -1,0 +1,55 @@
+.info-panel {
+  position: relative;
+  margin-top: 1rem;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  display: flex;
+  gap: 1rem;
+  background: #fff;
+  animation: info-fade 0.3s ease;
+}
+
+@keyframes info-fade {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.info-cover {
+  width: 200px;
+  height: auto;
+}
+
+.info-details {
+  flex: 1;
+}
+
+.info-credits {
+  list-style: none;
+  padding: 0;
+}
+
+.info-button {
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  background: #007bff;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}
+
+.info-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}

--- a/src/components/InfoPanel.jsx
+++ b/src/components/InfoPanel.jsx
@@ -1,0 +1,39 @@
+import './InfoPanel.css';
+
+const InfoPanel = ({ issue, onClose }) => {
+  if (!issue) return null;
+  return (
+    <div className="info-panel">
+      <button className="info-close" onClick={onClose} aria-label="Close">
+        &times;
+      </button>
+      <img src={issue.cover} alt={`${issue.title} cover`} className="info-cover" />
+      <div className="info-details">
+        <h2>{issue.title}</h2>
+        {issue.subtitle && <h4>{issue.subtitle}</h4>}
+        <p>{issue.description}</p>
+        <ul className="info-credits">
+          <li>
+            <strong>Writer:</strong> {issue.credits.writer}
+          </li>
+          <li>
+            <strong>Artist:</strong> {issue.credits.artist}
+          </li>
+          <li>
+            <strong>Letterer:</strong> {issue.credits.letterer}
+          </li>
+        </ul>
+        <a
+          href={issue.readerUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="info-button"
+        >
+          Read this issue
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default InfoPanel;

--- a/src/components/PreviewCarousel.css
+++ b/src/components/PreviewCarousel.css
@@ -1,0 +1,24 @@
+.preview-carousel {
+  padding: 1rem;
+}
+
+.preview-list {
+  display: flex;
+  overflow-x: auto;
+  gap: 1rem;
+  scroll-behavior: smooth;
+}
+
+.preview-card {
+  flex: 0 0 auto;
+  width: 200px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.preview-image {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+  display: block;
+}

--- a/src/components/PreviewCarousel.jsx
+++ b/src/components/PreviewCarousel.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import './PreviewCarousel.css';
+import { issues } from '../data/issues';
+import InfoPanel from './InfoPanel';
+
+const PreviewCarousel = () => {
+  const [selectedIssue, setSelectedIssue] = useState(null);
+
+  return (
+    <section className="preview-carousel">
+      <div className="preview-list">
+        {issues.map((issue) => (
+          <div
+            key={issue.id}
+            className="preview-card"
+            onClick={() => setSelectedIssue(issue)}
+          >
+            <img
+              src={issue.preview}
+              alt={`${issue.title} preview`}
+              className="preview-image"
+            />
+            <h3>{issue.title}</h3>
+          </div>
+        ))}
+      </div>
+      {selectedIssue && (
+        <InfoPanel issue={selectedIssue} onClose={() => setSelectedIssue(null)} />
+      )}
+    </section>
+  );
+};
+
+export default PreviewCarousel;

--- a/src/data/issues.js
+++ b/src/data/issues.js
@@ -1,0 +1,49 @@
+export const issues = [
+  {
+    id: 1,
+    title: 'Issue #1',
+    subtitle: 'The Beginning',
+    description:
+      'A mysterious event sets the stage for a slow-burn supernatural mystery in 1920s Colorado.',
+    cover: '/assets/issue1-cover.png',
+    preview: '/assets/issue1-preview.png',
+    credits: {
+      writer: 'Jane Doe',
+      artist: 'John Smith',
+      letterer: 'Anna Lee',
+    },
+    readerUrl: 'https://example.com/issue1',
+  },
+  {
+    id: 2,
+    title: 'Issue #2',
+    subtitle: 'Strange Encounters',
+    description:
+      'The mystery deepens as new characters arrive and secrets begin to surface.',
+    cover: '/assets/issue2-cover.png',
+    preview: '/assets/issue2-preview.png',
+    credits: {
+      writer: 'Jane Doe',
+      artist: 'John Smith',
+      letterer: 'Anna Lee',
+    },
+    readerUrl: 'https://example.com/issue2',
+  },
+  {
+    id: 3,
+    title: 'Issue #3',
+    subtitle: 'Revelations',
+    description:
+      'Tensions rise and revelations unfold, drawing the reader deeper into the supernatural.',
+    cover: '/assets/issue3-cover.png',
+    preview: '/assets/issue3-preview.png',
+    credits: {
+      writer: 'Jane Doe',
+      artist: 'John Smith',
+      letterer: 'Anna Lee',
+    },
+    readerUrl: 'https://example.com/issue3',
+  },
+];
+
+export default issues;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,6 +8,7 @@ import App from './App.jsx'
 import Prompter from './Prompter.jsx'
 import DevConsole from './DevConsole.jsx'
 import Updater from './Updater.jsx'
+import ReadPage from './ReadPage.jsx'
 
 export function DevIcon() {
   return (
@@ -28,9 +29,10 @@ createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <HashRouter>
       <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/prompter" element={<Prompter />} />
-        <Route path="/dev-console" element={<DevConsole />} />
+          <Route path="/" element={<App />} />
+          <Route path="/read" element={<ReadPage />} />
+          <Route path="/prompter" element={<Prompter />} />
+          <Route path="/dev-console" element={<DevConsole />} />
       </Routes>
       <button
         className="dev-console-button"


### PR DESCRIPTION
## Summary
- Add dedicated `ReadPage` with hero splash, preview carousel and expandable info panel for comic issues
- Centralize issue metadata under `src/data/issues.js`, referencing external asset paths so PNGs can be added later
- Wire "Read Now" and "Read this issue" buttons to each issue's reader URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fda887330832195a0bde208dbb21e