### PR TITLE
feat: disable link interactions in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,18 @@ process with the environment variable set, keeping the key outside the project.
 CI pipelines should supply `OPENAI_API_KEY` from a centrally managed secret
 store. The included GitHub Actions workflow uses a repository secret named
 `OPENAI_API_KEY`. Rotate this secret centrally without modifying the codebase.
+
+## Disabling Link Interactions
+
+Components that render arbitrary HTML should prevent links from navigating
+away from the app. Import `src/utils/disableLinks.css` and apply the
+`disable-links` class to the container:
+
+```jsx
+import './utils/disableLinks.css'
+
+<div className='disable-links' dangerouslySetInnerHTML={{ __html: html }} />
+```
+
+`TipTapEditor`, `Prompter`, and `ScriptViewer` already include this
+style. New components that render raw HTML should follow the same pattern.

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from 'react'
 import TipTapEditor from './TipTapEditor.jsx'
 import './Prompter.css'
+import './utils/disableLinks.css'
 
 const MARGIN_MIN = 0
 const MARGIN_MAX = 600
@@ -448,7 +449,7 @@ function Prompter() {
         }}
       >
         <div
-          className="script-output"
+          className="script-output disable-links"
           dangerouslySetInnerHTML={{
             __html: notecardMode ? slides[currentSlide] || '' : content,
           }}

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -2,6 +2,7 @@ import './ScriptViewer.css';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import TipTapEditor from './TipTapEditor.jsx';
 import { toast } from 'react-hot-toast';
+import './utils/disableLinks.css';
 
 function ScriptViewer({
   projectName,
@@ -247,7 +248,7 @@ useEffect(() => {
           </div>
         </div>
       )}
-      <div className="script-viewer-content">
+      <div className="script-viewer-content disable-links">
         {showContent && (
           <TipTapEditor initialHtml={scriptHtml || ''} onUpdate={handleEdit} />
         )}

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -4,6 +4,7 @@ import StarterKit from '@tiptap/starter-kit'
 import { TextStyle, Color } from '@tiptap/extension-text-style'
 import { toast } from 'react-hot-toast'
 import './TipTapEditor.css'
+import './utils/disableLinks.css'
 
 function TipTapEditor({ initialHtml = '', onUpdate }) {
   const containerRef = useRef(null)
@@ -216,7 +217,7 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
 
   return (
     <div ref={containerRef} className="tiptap-editor" onContextMenu={handleContextMenu}>
-      <EditorContent editor={editor} />
+      <EditorContent editor={editor} className="disable-links" />
       {menuPos && editor && (
         <div
           className="context-menu-root"

--- a/src/utils/disableLinks.css
+++ b/src/utils/disableLinks.css
@@ -1,0 +1,6 @@
+.disable-links a {
+  pointer-events: none;
+  cursor: default;
+  color: inherit;
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- add shared `disable-links` style to prevent anchor navigation
- apply link disabling to TipTapEditor, Prompter output, and ScriptViewer
- document link disabling approach in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4dd2f52b483218059ea81f2a3b56c