### PR TITLE
Use translateX for prompter settings panel

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -121,7 +121,7 @@
   height: 100vh;
   width: 220px;
   transform: translateX(-100%);
-  transition: transform 0.3s ease;
+  transition: transform 0.3s ease-in-out;
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -152,6 +152,12 @@
   cursor: pointer;
   padding: var(--space-2);
   border-radius: 0 4px 4px 0;
+  transform: translateX(0);
+  transition: transform 0.3s ease-in-out;
+}
+
+.main-settings-toggle.open {
+  transform: translateX(220px);
 }
 
 .toggle-btn {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -305,8 +305,7 @@ function Prompter() {
       <div className="resize-handle bottom-left" onMouseDown={(e) => startResize(e, 'bottom-left')} />
       <div className="resize-handle bottom-right" onMouseDown={(e) => startResize(e, 'bottom-right')} />
         <button
-          className="main-settings-toggle"
-          style={{ left: mainSettingsOpen ? '220px' : '0' }}
+          className={`main-settings-toggle ${mainSettingsOpen ? 'open' : ''}`}
           onClick={() => setMainSettingsOpen(!mainSettingsOpen)}
         >
           {mainSettingsOpen ? '←' : '→'}


### PR DESCRIPTION
## Summary
- Replace inline positioning for main settings toggle with CSS translateX classes
- Add transitions so settings panel and toggle slide smoothly

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5ccde10188321ade94c76bd999afd