### PR TITLE
feat: animate project sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -224,14 +224,19 @@ body {
   border: 2px dashed var(--accent-color);
 }
 
-.project-group.collapsed ul {
-  display: none;
-}
-
 .project-group ul {
   list-style: none;
   padding: 0;
   margin: 0;
+  max-height: 1000px;
+  opacity: 1;
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
+}
+
+.project-group ul.collapsed {
+  max-height: 0;
+  opacity: 0;
 }
 
 .project-group li {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -463,10 +463,7 @@ const FileManager = forwardRef(function FileManager({
         onDrop={handleRootDrop}
       >
         {projects.map((project) => (
-          <div
-            className={`project-group${collapsed[project.name] ? ' collapsed' : ''}`}
-            key={project.name}
-          >
+          <div className="project-group" key={project.name}>
             <div
               className={`project-header${hoverProject === project.name ? ' drop-target' : ''}`}
               onDragOver={handleDragOver}
@@ -538,7 +535,7 @@ const FileManager = forwardRef(function FileManager({
                 </>
               )}
             </div>
-            <ul>
+            <ul className={collapsed[project.name] ? 'collapsed' : ''}>
               {project.scripts
                 .slice()
                 .sort((a, b) => {


### PR DESCRIPTION
## Summary
- use a `collapsed` class on project script lists instead of inline display/height logic
- add `max-height`/`opacity` transitions so project groups slide open and closed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cce096a083219946b64643c15549