### PR TITLE
Render action menu list and animate its opening

### DIFF
--- a/src/ActionMenu.jsx
+++ b/src/ActionMenu.jsx
@@ -24,15 +24,13 @@ function ActionMenu({ actions }) {
       <button className="menu-toggle" onClick={() => setOpen(!open)}>
         ☰
       </button>
-      {open && (
-        <ul className="menu">
-          {actions.map(({ label, onClick }, idx) => (
-            <li key={idx}>
-              <button onClick={() => handleAction(onClick)}>{label}</button>
-            </li>
-          ))}
-        </ul>
-      )}
+      <ul className={`menu${open ? ' open' : ''}`}>
+        {actions.map(({ label, onClick }, idx) => (
+          <li key={idx}>
+            <button onClick={() => handleAction(onClick)}>{label}</button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/App.css
+++ b/src/App.css
@@ -360,6 +360,16 @@ body {
   padding: var(--space-1) 0;
   min-width: 120px;
   z-index: 10;
+  opacity: 0;
+  transform: scale(0.95);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.menu.open {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
 }
 
 .menu li button {


### PR DESCRIPTION
## Summary
- Always render the action menu list and toggle an `open` class in `ActionMenu.jsx`
- Add opacity and transform transitions so the menu scales and fades in when opened

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cce018d48321bcb90f294e3bb295