### PR TITLE
Add fade transition to ConfirmModal

### DIFF
--- a/src/ConfirmModal.css
+++ b/src/ConfirmModal.css
@@ -6,6 +6,14 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
+  opacity: 0;
+  transform: scale(1.05);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.confirm-modal-overlay.visible {
+  opacity: 1;
+  transform: scale(1);
 }
 
 .confirm-modal {
@@ -15,6 +23,14 @@
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   max-width: 300px;
   text-align: center;
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.confirm-modal.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .confirm-modal p {

--- a/src/ConfirmModal.jsx
+++ b/src/ConfirmModal.jsx
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './ConfirmModal.css';
 
+const ANIMATION_DURATION = 300; // ms
+
 function ConfirmModal({ message, onConfirm, onCancel }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // trigger visibility after mount
+    const id = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  const closeThen = (cb) => {
+    setVisible(false);
+    setTimeout(cb, ANIMATION_DURATION);
+  };
+
+  const handleCancel = () => closeThen(onCancel);
+  const handleConfirm = () => closeThen(onConfirm);
+
   return (
-    <div className="confirm-modal-overlay">
-      <div className="confirm-modal">
+    <div className={`confirm-modal-overlay ${visible ? 'visible' : ''}`}>
+      <div className={`confirm-modal ${visible ? 'visible' : ''}`}>
         <p>{message}</p>
         <div className="confirm-buttons">
-          <button onClick={onCancel}>Cancel</button>
-          <button className="delete-button" onClick={onConfirm}>Delete</button>
+          <button onClick={handleCancel}>Cancel</button>
+          <button className="delete-button" onClick={handleConfirm}>Delete</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- animate ConfirmModal overlay and modal with opacity and transform transitions
- toggle visibility class to play open/close animations

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cce146488321bac925cd61735091