### PR TITLE
feat: slide left panel offscreen when collapsed

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,9 +27,10 @@ body {
   padding: calc(var(--space-4) + var(--space-1));
   overflow-y: auto;
   overflow-x: visible;
+  transition: transform 0.3s ease;
 }
 .left-panel.collapsed {
-  display: none;
+  transform: translateX(-100%);
 }
 
 .right-panel {


### PR DESCRIPTION
## Summary
- slide left panel offscreen using `transform: translateX(-100%)` when collapsed
- add a `transition` on the left panel for smooth sliding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cce418f083219719c2daf038bd2b