### PR TITLE
Sync overlay scroll with container

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -200,6 +200,7 @@
   background: transparent;
   border-radius: 0;
   box-shadow: none;
+  overflow: visible;
 }
 
 .stop-button {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -50,6 +50,14 @@ function Prompter() {
   // all settings are now accessible from a single panel
   const [mainSettingsOpen, setMainSettingsOpen] = useState(false)
   const containerRef = useRef(null)
+  const editorRef = useRef(null)
+
+  const handleEditorReady = (editor) => {
+    editorRef.current = editor
+    if (containerRef.current) {
+      editor.view.dom.scrollTop = containerRef.current.scrollTop
+    }
+  }
 
   const handleEdit = (html) => {
     setContent(html)
@@ -81,6 +89,19 @@ function Prompter() {
       }
     }
   }
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+    const syncScroll = () => {
+      const editor = editorRef.current
+      if (editor) {
+        editor.view.dom.scrollTop = container.scrollTop
+      }
+    }
+    container.addEventListener('scroll', syncScroll)
+    return () => container.removeEventListener('scroll', syncScroll)
+  }, [])
 
   useEffect(() => {
     if (!projectName) return
@@ -497,7 +518,11 @@ function Prompter() {
           className="editor-overlay"
           style={{ padding: `2rem ${margin}px` }}
         >
-          <TipTapEditor initialHtml={content} onUpdate={handleEdit} />
+          <TipTapEditor
+            initialHtml={content}
+            onUpdate={handleEdit}
+            onReady={handleEditorReady}
+          />
         </div>
       </div>
       {notecardMode && slides.length > 1 && (

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast'
 import './TipTapEditor.css'
 import './utils/disableLinks.css'
 
-function TipTapEditor({ initialHtml = '', onUpdate }) {
+function TipTapEditor({ initialHtml = '', onUpdate, onReady }) {
   const containerRef = useRef(null)
   const editor = useEditor({
     extensions: [StarterKit, TextStyle, Color],
@@ -15,6 +15,10 @@ function TipTapEditor({ initialHtml = '', onUpdate }) {
       onUpdate?.(editor.getHTML())
     },
   })
+
+  useEffect(() => {
+    if (editor) onReady?.(editor)
+  }, [editor, onReady])
 
   const [menuPos, setMenuPos] = useState(null)
   const [activeMenu, setActiveMenu] = useState('root')


### PR DESCRIPTION
## Summary
- expose TipTap editor instance via new `onReady` callback
- prompter stores the editor ref and mirrors container scroll to keep overlay aligned
- prevent nested ProseMirror scrolling by inheriting container overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --test tests/*.test.cjs`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5cf79535c832194608ab57d520bd0