### PR TITLE
feat: ensure editor and script output stay synchronized

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -59,6 +59,23 @@ function Prompter() {
     }
   }
 
+  const verifySync = () => {
+    const editor = editorRef.current
+    const container = containerRef.current
+    if (!editor || !container) return
+    const editorHtml = editor.getHTML()
+    const outputEl = container.querySelector('.script-output')
+    if (!outputEl) return
+    const outputHtml = outputEl.innerHTML
+    if (editorHtml !== outputHtml) {
+      console.warn('Editor and script output out of sync; resetting')
+      setContent(editorHtml)
+      if (editor?.commands?.setContent) {
+        editor.commands.setContent(editorHtml, false)
+      }
+    }
+  }
+
   const handleEdit = (html) => {
     setContent(html)
     if (!window.electronAPI?.sendUpdatedScript) {
@@ -66,6 +83,7 @@ function Prompter() {
       return
     }
     window.electronAPI.sendUpdatedScript(html)
+    verifySync()
   }
 
   const resetDefaults = () => {


### PR DESCRIPTION
## Summary
- add `verifySync` helper to compare editor content and displayed script
- call `verifySync` after each edit to keep elements in sync and warn on mismatch

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5d9169f7c8321a42579f8d350f428