### PR TITLE
feat: toggle prompter editing layers

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -175,32 +175,13 @@
 }
 
 .script-output {
-  pointer-events: none;
-}
-
-.editor-overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  pointer-events: none;
-  z-index: 1;
-}
-
-.editor-overlay .tiptap-editor {
   pointer-events: auto;
-  color: transparent;
-  caret-color: #e0e0e0;
-  background: transparent;
+  user-select: none;
 }
 
-.editor-overlay .tiptap-editor .ProseMirror {
-  outline: none;
-  background: transparent;
-  border-radius: 0;
-  box-shadow: none;
-  overflow: visible;
+.editor-layer {
+  position: relative;
+  z-index: 1;
 }
 
 .stop-button {


### PR DESCRIPTION
## Summary
- Use a single TipTap editor instance and toggle visibility between view and edit modes
- Move editor offscreen in view mode and render non-selectable HTML instead
- Exit edit mode on outside click, syncing content with a debounced update

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5df87c770832183ac89eb9cc9b78c