### PR TITLE
Remove padding from editor layer and sync editor styles

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -571,7 +571,7 @@ function Prompter() {
           ref={editorContainerRef}
           className="editor-layer"
           style={{
-            padding: `2rem ${margin}px`,
+            padding: 0,
             position: isEditing ? 'relative' : 'absolute',
             left: isEditing ? 0 : '-10000px',
             top: 0,
@@ -581,6 +581,11 @@ function Prompter() {
             initialHtml={content}
             onUpdate={handleEdit}
             onReady={handleEditorReady}
+            style={{
+              fontSize: `${fontSize}rem`,
+              lineHeight,
+              textAlign,
+            }}
           />
         </div>
       </div>

--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast'
 import './TipTapEditor.css'
 import './utils/disableLinks.css'
 
-function TipTapEditor({ initialHtml = '', onUpdate, onReady }) {
+function TipTapEditor({ initialHtml = '', onUpdate, onReady, style = {} }) {
   const containerRef = useRef(null)
   const editor = useEditor({
     extensions: [StarterKit, TextStyle, Color],
@@ -220,7 +220,12 @@ function TipTapEditor({ initialHtml = '', onUpdate, onReady }) {
   }
 
   return (
-    <div ref={containerRef} className="tiptap-editor" onContextMenu={handleContextMenu}>
+    <div
+      ref={containerRef}
+      className="tiptap-editor"
+      onContextMenu={handleContextMenu}
+      style={style}
+    >
       <EditorContent editor={editor} className="disable-links" />
       {menuPos && editor && (
         <div


### PR DESCRIPTION
## Summary
- Remove extra padding from Prompter's editor layer so the editor occupies full padded area
- Pass font size, line height, and text alignment to TipTapEditor for consistency with rendered view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5e44cbcf48321a3e1c1cb2703d52c