### PR TITLE
Ensure ProseMirror inherits base styles

### DIFF
--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -12,9 +12,14 @@
 
 .tiptap-editor .ProseMirror {
   outline: none;
-  background: #2a2a2a;
-  border-radius: 6px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  background: transparent;
+  border-radius: 0;
+  box-shadow: none;
+  color: inherit;
+  line-height: inherit;
+  text-align: inherit;
+  white-space: pre-wrap;
+  word-break: normal;
 }
 
 /* Context menu base */


### PR DESCRIPTION
## Summary
- Clear background, border radius and shadow from TipTap editor content area
- Inherit color, line-height and text alignment so themes cascade correctly
- Preserve whitespace and normal word breaks in editor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5e4590ef083218d8e2736ef097b0c