### PR TITLE
Place caret at clicked position when editing script

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -90,10 +90,18 @@ function Prompter() {
     }
   }, [])
 
-  const enterEdit = () => {
+  const enterEdit = (e) => {
+    const { clientX, clientY } = e
     setIsEditing(true)
     setTimeout(() => {
-      editorRef.current?.commands.focus('end')
+      const editor = editorRef.current
+      if (!editor) return
+      const pos = editor.view.posAtCoords({ left: clientX, top: clientY })
+      if (pos) {
+        editor.chain().focus().setTextSelection(pos.pos).run()
+      } else {
+        editor.commands.focus('end')
+      }
     }, 0)
   }
 


### PR DESCRIPTION
## Summary
- Position editor caret at the user's click when entering edit mode using ProseMirror's `posAtCoords`
- Fallback to focusing at the end if position can't be resolved

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5f427c5e0832196c66998d379e231