### PR TITLE
fix: stabilize tiptap editor

### DIFF
--- a/src/TipTapEditor.jsx
+++ b/src/TipTapEditor.jsx
@@ -8,17 +8,26 @@ import './utils/disableLinks.css'
 
 function TipTapEditor({ initialHtml = '', onUpdate, onReady, style = {} }) {
   const containerRef = useRef(null)
-  const editor = useEditor({
-    extensions: [StarterKit, TextStyle, Color],
-    content: initialHtml,
-    onUpdate: ({ editor }) => {
-      onUpdate?.(editor.getHTML())
+  const editor = useEditor(
+    {
+      extensions: [StarterKit, TextStyle, Color],
+      content: initialHtml,
+      onUpdate: ({ editor }) => {
+        onUpdate?.(editor.getHTML())
+      },
     },
-  })
+    [],
+  )
 
   useEffect(() => {
     if (editor) onReady?.(editor)
   }, [editor, onReady])
+
+  useEffect(() => {
+    if (editor && editor.getHTML() !== initialHtml) {
+      editor.commands.setContent(initialHtml, false)
+    }
+  }, [editor, initialHtml])
 
   const [menuPos, setMenuPos] = useState(null)
   const [activeMenu, setActiveMenu] = useState('root')


### PR DESCRIPTION
## Summary
- stabilize `useEditor` instance with empty dependency array to prevent re-creation
- sync editor content with `initialHtml` via effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6016be8e88321913271611cd3f909