### PR TITLE
feat: add splash screen

### DIFF
--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -1,0 +1,17 @@
+.splash-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.splash-screen img {
+  max-width: 80%;
+  height: auto;
+}

--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,0 +1,9 @@
+import './SplashScreen.css';
+
+const SplashScreen = () => (
+  <div className="splash-screen">
+    <img src="/splash.png" alt="LeaderPrompt" />
+  </div>
+);
+
+export default SplashScreen;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { HashRouter, Routes, Route } from 'react-router-dom'
 import { Toaster } from 'react-hot-toast'
@@ -9,9 +9,21 @@ import Prompter from './Prompter.jsx'
 import DevConsole from './DevConsole.jsx'
 import Updater from './Updater.jsx'
 import ReadPage from './ReadPage.jsx'
+import SplashScreen from './components/SplashScreen.jsx'
 
-createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+export default function Root() {
+  const [showSplash, setShowSplash] = useState(true)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setShowSplash(false), 2000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  if (showSplash) {
+    return <SplashScreen />
+  }
+
+  return (
     <HashRouter>
       <Routes>
           <Route path="/" element={<App />} />
@@ -22,5 +34,11 @@ createRoot(document.getElementById('root')).render(
       <Updater />
       <Toaster position="top-right" />
     </HashRouter>
+  )
+}
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <Root />
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- show splash screen on black background for 2 seconds during startup
- include reusable SplashScreen component and styles

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a607ad821c8321af1450926e73f713