### PR TITLE
Adjust splash screen image size

### DIFF
--- a/src/components/SplashScreen.css
+++ b/src/components/SplashScreen.css
@@ -12,6 +12,7 @@
 }
 
 .splash-screen img {
-  max-width: 80%;
+  max-width: 40vw;
+  max-height: 40vh;
   height: auto;
 }


### PR DESCRIPTION
## Summary
- Reduce splash screen image size to 40% of viewport and add max-height to keep it within window bounds

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60e02134083218a1658b994ba2ee4