### PR TITLE
Handle root drag/drop events over child elements

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -349,19 +349,16 @@ const FileManager = forwardRef(function FileManager({
   };
 
   const handleRootDragEnter = (e) => {
-    if (e.target === e.currentTarget) {
-      const folders = getDroppedFolders(e.dataTransfer);
-      if (folders.length) setRootDrag(true);
-    }
+    const folders = getDroppedFolders(e.dataTransfer);
+    if (folders.length) setRootDrag(true);
   };
 
   const handleRootDragLeave = (e) => {
-    if (e.target === e.currentTarget) setRootDrag(false);
+    if (!e.currentTarget.contains(e.relatedTarget)) setRootDrag(false);
   };
 
   const handleRootDrop = async (e) => {
     e.preventDefault();
-    if (e.target !== e.currentTarget) return;
     setRootDrag(false);
     const folderPaths = getDroppedFolders(e.dataTransfer);
     const fileItems = Array.from(e.dataTransfer.files || []);


### PR DESCRIPTION
## Summary
- Allow FileManager root drag/drop handlers to run when interacting with child elements
- Prevent spurious dragleave by delegating with `relatedTarget`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a611b9d5d483219259fb5a0370f80a