### PR TITLE
feat: enable left panel folder drops

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,6 +29,9 @@ body {
   overflow-x: visible;
   transition: transform 0.3s ease;
 }
+.left-panel.drop-target {
+  border: 2px dashed var(--accent-color);
+}
 .left-panel.collapsed {
   transform: translateX(-100%);
 }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -358,6 +358,7 @@ const FileManager = forwardRef(function FileManager({
 
   const handleRootDrop = async (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setRootDrag(false);
     const fileItems = Array.from(e.dataTransfer.files || []);
     const allPaths = fileItems.map((f) => f.path).filter(Boolean);


### PR DESCRIPTION
## Summary
- allow dropping folders onto the left panel to import them as projects or quick scripts
- highlight the left panel during drag and prevent duplicate drops

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a63157f7008321be7c971b0407824b