### PR TITLE
Unload script viewer when deleting scripts

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -253,6 +253,9 @@ const FileManager = forwardRef(function FileManager({
           toast.error('Failed to delete project');
         } else {
           toast.success('Project deleted');
+          if (currentProject === projectName) {
+            onScriptSelect(null, null);
+          }
         }
         await loadProjects();
       },
@@ -274,6 +277,12 @@ const FileManager = forwardRef(function FileManager({
           toast.error('Failed to delete script');
         } else {
           toast.success('Script deleted');
+          if (
+            currentProject === projectName &&
+            currentScript === scriptName
+          ) {
+            onScriptSelect(null, null);
+          }
         }
         await loadProjects();
       },


### PR DESCRIPTION
## Summary
- Clear the selected script when its project or script is deleted so the Script Viewer closes.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a63187e1d08321af90a7a37c16b4c0