### PR TITLE
Handle root drag-and-drop of directories for script import

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -865,6 +865,7 @@ ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) =>
 
   expanded = Array.from(new Set(expanded));
 
+  let importedCount = 0;
   for (const file of expanded) {
     try {
       const result = await mammoth.convertToHtml({ path: file });
@@ -883,12 +884,13 @@ ipcMain.handle('import-scripts-to-project', async (_, filePaths, projectName) =>
       const buffer = await htmlToDocx(html);
       await fs.promises.writeFile(dest, buffer);
       log(`Imported script: ${safeName} → ${dest}`);
+      importedCount++;
     } catch (err) {
       error(`Failed to import file ${file}:`, err);
     }
   }
-
   updateProjectMetadata(projectName);
+  return importedCount;
 });
 
 ipcMain.handle('filter-directories', async (_, paths) => {


### PR DESCRIPTION
## Summary
- Import dropped directories by passing them to `importScriptsToProject` when no `.docx` files are directly dropped
- Return the number of imported scripts from the main process to determine when to show an error toast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a633ebf8b483219633fa2d98a93d59