### PR TITLE
Fix root drag highlight to await folder resolution

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -357,8 +357,9 @@ const FileManager = forwardRef(function FileManager({
   };
 
   const handleRootDragEnter = (e) => {
-    const folders = getDroppedFolders(e.dataTransfer);
-    if (folders.length) setRootDrag(true);
+    getDroppedFolders(e.dataTransfer).then((folders) => {
+      setRootDrag(folders.length > 0);
+    });
   };
 
   const handleRootDragLeave = (e) => {


### PR DESCRIPTION
## Summary
- Await folder filtering before setting root drag highlight

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68addc9c4acc8321a98c525231665a2c