### PR TITLE
feat: support directory drag-and-drop via dataTransfer items

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,9 +60,36 @@ function App() {
     e.preventDefault();
   };
 
+  const parseDataTransferItems = async (dataTransfer) => {
+    const items = Array.from(dataTransfer?.items || []);
+    const folderPaths = [];
+    const filePaths = [];
+    for (const item of items) {
+      if (item.kind !== 'file') continue;
+      let entry = null;
+      if (item.webkitGetAsEntry) {
+        entry = item.webkitGetAsEntry();
+      } else if (item.getAsFileSystemHandle) {
+        try {
+          entry = await item.getAsFileSystemHandle();
+        } catch {
+          entry = null;
+        }
+      }
+      const file = item.getAsFile?.();
+      const path = file?.path;
+      if (!path) continue;
+      if (entry?.isDirectory) folderPaths.push(path);
+      else filePaths.push(path);
+    }
+    return { folderPaths, filePaths };
+  };
+
   const handleLeftDragEnter = (e) => {
     if (e.target.closest?.('.file-manager')) return;
-    setLeftDrag(true);
+    parseDataTransferItems(e.dataTransfer).then(({ folderPaths }) => {
+      setLeftDrag(folderPaths.length > 0);
+    });
   };
 
   const handleLeftDragLeave = (e) => {
@@ -73,15 +100,10 @@ function App() {
     e.preventDefault();
     if (e.target.closest?.('.file-manager')) return;
     setLeftDrag(false);
-    const fileItems = Array.from(e.dataTransfer.files || []);
-    const allPaths = fileItems.map((f) => f.path).filter(Boolean);
-    let folderPaths = [];
-    if (window.electronAPI?.filterDirectories) {
-      folderPaths = await window.electronAPI.filterDirectories(allPaths);
-    }
-    const filePaths = allPaths
-      .filter((p) => !folderPaths.includes(p))
-      .filter((p) => p?.toLowerCase().endsWith('.docx'));
+    const { folderPaths, filePaths } = await parseDataTransferItems(
+      e.dataTransfer,
+    );
+    const docxPaths = filePaths.filter((p) => p?.toLowerCase().endsWith('.docx'));
     if (folderPaths.length) {
       if (!window.electronAPI?.importFoldersAsProjects) {
         console.error('electronAPI unavailable');
@@ -90,18 +112,18 @@ function App() {
       await window.electronAPI.importFoldersAsProjects(folderPaths);
       if (fileManagerRef.current?.reload) await fileManagerRef.current.reload();
       toast.success('Projects imported');
-    } else if (fileItems.length) {
+    } else if (filePaths.length) {
       const projectName = 'Quick Scripts';
       if (!window.electronAPI?.importScriptsToProject) {
         console.error('electronAPI unavailable');
         toast.error('Unable to import scripts');
         return;
       }
-      if (!filePaths.length) {
+      if (!docxPaths.length) {
         toast.error('Only .docx files can be imported');
         return;
       }
-      await window.electronAPI.importScriptsToProject(filePaths, projectName);
+      await window.electronAPI.importScriptsToProject(docxPaths, projectName);
       if (fileManagerRef.current?.reload) await fileManagerRef.current.reload();
       toast.success('Scripts imported');
     }

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -344,16 +344,34 @@ const FileManager = forwardRef(function FileManager({
     e.dataTransfer.dropEffect = 'copy';
   };
 
-  const getDroppedFolders = async (dataTransfer) => {
-    const paths = Array.from(dataTransfer.files || [])
-      .map((f) => f.path)
-      .filter(Boolean);
-    if (!paths.length) return [];
-    if (!window.electronAPI?.filterDirectories) {
-      console.error('electronAPI unavailable');
-      return [];
+  const parseDataTransferItems = async (dataTransfer) => {
+    const items = Array.from(dataTransfer?.items || []);
+    const folderPaths = [];
+    const filePaths = [];
+    for (const item of items) {
+      if (item.kind !== 'file') continue;
+      let entry = null;
+      if (item.webkitGetAsEntry) {
+        entry = item.webkitGetAsEntry();
+      } else if (item.getAsFileSystemHandle) {
+        try {
+          entry = await item.getAsFileSystemHandle();
+        } catch {
+          entry = null;
+        }
+      }
+      const file = item.getAsFile?.();
+      const path = file?.path;
+      if (!path) continue;
+      if (entry?.isDirectory) folderPaths.push(path);
+      else filePaths.push(path);
     }
-    return await window.electronAPI.filterDirectories(paths);
+    return { folderPaths, filePaths };
+  };
+
+  const getDroppedFolders = async (dataTransfer) => {
+    const { folderPaths } = await parseDataTransferItems(dataTransfer);
+    return folderPaths;
   };
 
   const handleRootDragEnter = (e) => {
@@ -370,16 +388,10 @@ const FileManager = forwardRef(function FileManager({
     e.preventDefault();
     e.stopPropagation();
     setRootDrag(false);
-    const fileItems = Array.from(e.dataTransfer.files || []);
-    if (!fileItems.length) return;
-    const allPaths = fileItems.map((f) => f.path).filter(Boolean);
-    let folderPaths = [];
-    if (window.electronAPI?.filterDirectories) {
-      folderPaths = await window.electronAPI.filterDirectories(allPaths);
-    }
-    const filePaths = allPaths
-      .filter((p) => !folderPaths.includes(p))
-      .filter((p) => p?.toLowerCase().endsWith('.docx'));
+    const { folderPaths, filePaths } = await parseDataTransferItems(
+      e.dataTransfer,
+    );
+    const docxPaths = filePaths.filter((p) => p?.toLowerCase().endsWith('.docx'));
     if (folderPaths.length > 0) {
       if (!window.electronAPI?.importFoldersAsProjects) {
         console.error('electronAPI unavailable');
@@ -397,12 +409,12 @@ const FileManager = forwardRef(function FileManager({
       toast.error('Unable to import scripts');
       return;
     }
-    if (!filePaths.length) {
-      toast.error('Only .docx files can be imported');
+    if (!docxPaths.length) {
+      if (filePaths.length) toast.error('Only .docx files can be imported');
       return;
     }
     const imported = await window.electronAPI.importScriptsToProject(
-      filePaths,
+      docxPaths,
       projectName,
     );
     await loadProjects();


### PR DESCRIPTION
## Summary
- detect folders by inspecting `DataTransfer.items` using `webkitGetAsEntry` or `getAsFileSystemHandle`
- only highlight drag targets when directories are present
- keep `.docx` filtering when importing scripts, while allowing folders to import as projects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade29bc2b883219de88806c759d78f