### PR TITLE
Handle sandboxed drag-and-drop without file paths

### DIFF
--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -49,8 +49,12 @@ const api = {
   // Script import/load controls
   importScriptsToProject: (filePaths, projectName) =>
     ipcRenderer.invoke('import-scripts-to-project', filePaths, projectName),
+  importFilesToProject: (files, projectName) =>
+    ipcRenderer.invoke('import-files-to-project', files, projectName),
   importFoldersAsProjects: (folderPaths) =>
     ipcRenderer.invoke('import-folders-as-projects', folderPaths),
+  importFoldersDataAsProjects: (folders) =>
+    ipcRenderer.invoke('import-folders-data-as-projects', folders),
   filterDirectories: (paths) => ipcRenderer.invoke('filter-directories', paths),
   getScriptsForProject: (projectName) =>
     ipcRenderer.invoke('get-scripts-for-project', projectName),

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,47 +59,75 @@ function App() {
   const handleLeftDragOver = (e) => {
     e.preventDefault();
   };
+  const readAllFiles = async (handle) => {
+    const files = [];
+    if (!handle) return files;
+    if (handle.kind === 'file' || handle.isFile) {
+      const file = handle.getFile
+        ? await handle.getFile()
+        : await new Promise((res, rej) => handle.file(res, rej));
+      files.push(file);
+    } else if (handle.kind === 'directory' || handle.isDirectory) {
+      if (handle.entries) {
+        for await (const [, child] of handle.entries()) {
+          files.push(...(await readAllFiles(child)));
+        }
+      } else if (handle.values) {
+        for await (const child of handle.values()) {
+          files.push(...(await readAllFiles(child)));
+        }
+      } else if (handle.createReader) {
+        const reader = handle.createReader();
+        const readEntries = () =>
+          new Promise((resolve) => reader.readEntries(resolve));
+        let entries = await readEntries();
+        while (entries.length) {
+          for (const entry of entries) {
+            files.push(...(await readAllFiles(entry)));
+          }
+          entries = await readEntries();
+        }
+      }
+    }
+    return files;
+  };
 
   const parseDataTransferItems = async (dataTransfer) => {
     const items = Array.from(dataTransfer?.items || []);
-    const folderPaths = [];
-    let filePaths = [];
+    const folders = [];
+    const files = [];
     for (const item of items) {
       if (item.kind !== 'file') continue;
-      let entry = null;
-      if (item.webkitGetAsEntry) {
-        entry = item.webkitGetAsEntry();
-      } else if (item.getAsFileSystemHandle) {
+      let handle = null;
+      if (item.getAsFileSystemHandle) {
         try {
-          entry = await item.getAsFileSystemHandle();
+          handle = await item.getAsFileSystemHandle();
         } catch {
-          entry = null;
+          handle = null;
         }
+      } else if (item.webkitGetAsEntry) {
+        handle = item.webkitGetAsEntry();
       }
-      const file = item.getAsFile?.();
-      const path = file?.path;
-      if (!path) continue;
-      if (entry?.isDirectory) folderPaths.push(path);
-      else filePaths.push(path);
-    }
-    if (!folderPaths.length && !filePaths.length && dataTransfer?.files?.length) {
-      const allPaths = Array.from(dataTransfer.files)
-        .map((f) => f.path)
-        .filter(Boolean);
-      let dirs = [];
-      if (window.electronAPI?.filterDirectories) {
-        dirs = await window.electronAPI.filterDirectories(allPaths);
+      if (handle && (handle.kind === 'directory' || handle.isDirectory)) {
+        const dirFiles = await readAllFiles(handle);
+        folders.push({ name: handle.name, files: dirFiles });
+        files.push(...dirFiles);
+      } else {
+        const file = item.getAsFile
+          ? item.getAsFile()
+          : handle?.getFile
+            ? await handle.getFile()
+            : null;
+        if (file) files.push(file);
       }
-      folderPaths.push(...dirs);
-      filePaths = allPaths.filter((p) => !dirs.includes(p));
     }
-    return { folderPaths, filePaths };
+    return { folders, files };
   };
 
   const handleLeftDragEnter = (e) => {
     if (e.target.closest?.('.file-manager')) return;
-    parseDataTransferItems(e.dataTransfer).then(({ folderPaths }) => {
-      setLeftDrag(folderPaths.length > 0);
+    parseDataTransferItems(e.dataTransfer).then(({ folders }) => {
+      setLeftDrag(folders.length > 0);
     });
   };
 
@@ -111,32 +139,49 @@ function App() {
     e.preventDefault();
     if (e.target.closest?.('.file-manager')) return;
     setLeftDrag(false);
-    const { folderPaths, filePaths } = await parseDataTransferItems(
-      e.dataTransfer,
+    const { folders, files } = await parseDataTransferItems(e.dataTransfer);
+    const docxFiles = files.filter((f) =>
+      f.name.toLowerCase().endsWith('.docx'),
     );
-    const docxPaths = filePaths.filter((p) => p?.toLowerCase().endsWith('.docx'));
-    if (folderPaths.length) {
-      if (!window.electronAPI?.importFoldersAsProjects) {
+    if (folders.length) {
+      if (!window.electronAPI?.importFoldersDataAsProjects) {
         console.error('electronAPI unavailable');
         return;
       }
-      await window.electronAPI.importFoldersAsProjects(folderPaths);
+      const payload = await Promise.all(
+        folders.map(async (f) => ({
+          name: f.name,
+          files: await Promise.all(
+            f.files
+              .filter((file) => file.name.toLowerCase().endsWith('.docx'))
+              .map(async (file) => ({
+                name: file.name,
+                data: await file.arrayBuffer(),
+              })),
+          ),
+        })),
+      );
+      await window.electronAPI.importFoldersDataAsProjects(payload);
       if (fileManagerRef.current?.reload) await fileManagerRef.current.reload();
       toast.success('Projects imported');
-    } else if (filePaths.length) {
+    } else if (docxFiles.length) {
       const projectName = 'Quick Scripts';
-      if (!window.electronAPI?.importScriptsToProject) {
+      if (!window.electronAPI?.importFilesToProject) {
         console.error('electronAPI unavailable');
         toast.error('Unable to import scripts');
         return;
       }
-      if (!docxPaths.length) {
-        toast.error('Only .docx files can be imported');
-        return;
-      }
-      await window.electronAPI.importScriptsToProject(docxPaths, projectName);
+      const payload = await Promise.all(
+        docxFiles.map(async (file) => ({
+          name: file.name,
+          data: await file.arrayBuffer(),
+        })),
+      );
+      await window.electronAPI.importFilesToProject(payload, projectName);
       if (fileManagerRef.current?.reload) await fileManagerRef.current.reload();
       toast.success('Scripts imported');
+    } else if (files.length) {
+      toast.error('Only .docx files can be imported');
     }
   };
 


### PR DESCRIPTION
## Summary
- replace path-based drag-and-drop handling with File/FileSystemHandle traversal and IPC of file data
- add IPC endpoints to import dropped files or folders using in-memory buffers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade6d49d7883218d99387212332003