### PR TITLE
Handle single file drops

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -96,6 +96,10 @@ function App() {
     const items = Array.from(dataTransfer?.items || []);
     const folders = [];
     const files = [];
+    if (!items.length && dataTransfer?.files?.length) {
+      files.push(...Array.from(dataTransfer.files));
+      return { folders, files };
+    }
     for (const item of items) {
       if (item.kind !== 'file') continue;
       let handle = null;

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -390,6 +390,11 @@ const FileManager = forwardRef(function FileManager({
     const items = Array.from(dataTransfer?.items || []);
     const folders = [];
     const files = [];
+    if (!items.length && dataTransfer?.files?.length) {
+      files.push(...Array.from(dataTransfer.files));
+      console.log('Parsed items', { folders, files });
+      return { folders, files };
+    }
     for (const item of items) {
       if (item.kind !== 'file') continue;
       let handle = null;

--- a/tests/context-menu.test.js
+++ b/tests/context-menu.test.js
@@ -1,3 +1,4 @@
+/* global global, setImmediate */
 import test from 'node:test'
 import assert from 'node:assert'
 import { JSDOM } from 'jsdom'


### PR DESCRIPTION
## Summary
- fallback to `dataTransfer.files` when `dataTransfer.items` is empty
- allow single .docx drag-and-drop imports
- fix lint errors in context menu tests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node --input-type=module - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68adf1fa38e883218fa5911bc853473b