### PR TITLE
Report root drag state to left panel for folder imports

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -202,6 +202,7 @@ function App() {
             loadedScript={loadedScript}
             currentProject={selectedProject}
             currentScript={selectedScript}
+            onRootDragStateChange={setLeftDrag}
           />
         )}
       </div>

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -72,6 +72,7 @@ const FileManager = forwardRef(function FileManager({
   loadedScript,
   currentProject,
   currentScript,
+  onRootDragStateChange,
 }, ref) {
   const [projects, setProjects] = useState([]);
   const [newProjectName, setNewProjectName] = useState('');
@@ -427,13 +428,18 @@ const FileManager = forwardRef(function FileManager({
   const handleRootDragEnter = (e) => {
     getDroppedFolders(e.dataTransfer).then((folders) => {
       console.log('Root drag enter', folders);
-      setRootDrag(folders.length > 0);
+      const dragging = folders.length > 0;
+      setRootDrag(dragging);
+      onRootDragStateChange?.(dragging);
     });
   };
 
   const handleRootDragLeave = (e) => {
     console.log('Root drag leave');
-    if (!e.currentTarget.contains(e.relatedTarget)) setRootDrag(false);
+    if (!e.currentTarget.contains(e.relatedTarget)) {
+      setRootDrag(false);
+      onRootDragStateChange?.(false);
+    }
   };
 
   const handleRootDrop = async (e) => {
@@ -441,6 +447,7 @@ const FileManager = forwardRef(function FileManager({
     e.preventDefault();
     e.stopPropagation();
     setRootDrag(false);
+    onRootDragStateChange?.(false);
     const { folders, files } = await parseDataTransferItems(e.dataTransfer);
     console.log('Root drop items', { folders, files });
     if (folders.length > 0) {


### PR DESCRIPTION
## Summary
- add `onRootDragStateChange` callback to `FileManager` and notify on drag enter/leave
- toggle left panel `drop-target` class via new callback so dragging folders anywhere over the panel shows border

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: no-undef in tests)*
- `npx eslint src/FileManager.jsx src/App.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68adf1f6a69c832189ab480ff33fd058