### PR TITLE
Handle drag enter for file drop

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -126,9 +126,23 @@ function App() {
 
   const handleLeftDragEnter = (e) => {
     if (e.target.closest?.('.file-manager')) return;
-    parseDataTransferItems(e.dataTransfer).then(({ folders }) => {
-      setLeftDrag(folders.length > 0);
-    });
+    if (e.dataTransfer?.types?.includes('Files')) setLeftDrag(true);
+    parseDataTransferItems(e.dataTransfer)
+      .then(({ folders }) => {
+        if (folders.length > 0 || e.dataTransfer.files?.length) {
+          setLeftDrag(true);
+        } else {
+          setLeftDrag(false);
+        }
+      })
+      .catch((err) => {
+        console.error('Error parsing drag items', err);
+        if (e.dataTransfer.files?.length) {
+          setLeftDrag(true);
+        } else {
+          setLeftDrag(false);
+        }
+      });
   };
 
   const handleLeftDragLeave = (e) => {


### PR DESCRIPTION
## Summary
- highlight left panel immediately when dragging files
- fallback to `dataTransfer.files` if directory parsing returns nothing
- log parsing errors for easier debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-undef in tests)*
- `npx eslint src/App.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68adf7696b60832195ae89f0c0cef7e3