### PR TITLE
refactor: cache DataTransfer on drop

### DIFF
--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -509,13 +509,15 @@ const FileManager = forwardRef(function FileManager({
   };
 
   const handleDrop = async (e, projectName, index) => {
+    e.persist?.();
+    const dataTransfer = e.dataTransfer;
     console.log('Drop', { projectName, index, dragInfo });
     e.preventDefault();
     e.stopPropagation();
-    const external = e.dataTransfer.files && e.dataTransfer.files.length;
+    const external = dataTransfer.files && dataTransfer.files.length;
     if (external && !dragInfo) {
       console.log('External drop detected');
-      const { folders, files } = await parseDataTransferItems(e.dataTransfer);
+      const { folders, files } = await parseDataTransferItems(dataTransfer);
       const allFiles = [
         ...files,
         ...folders.flatMap((f) => f.files),
@@ -524,7 +526,7 @@ const FileManager = forwardRef(function FileManager({
         f.name.toLowerCase().endsWith('.docx'),
       );
       if (!docxFiles.length) {
-        const fallback = Array.from(e.dataTransfer.files || []);
+        const fallback = Array.from(dataTransfer.files || []);
         docxFiles = fallback.filter((f) =>
           f.name.toLowerCase().endsWith('.docx'),
         );


### PR DESCRIPTION
## Summary
- store `DataTransfer` at start of `handleDrop` and reuse the variable
- call `persist` on the event to avoid premature pooling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b5942488321888c3d3a4f59ecb5