### PR TITLE
feat: add detailed drop logging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -94,14 +94,33 @@ function App() {
 
   const parseDataTransferItems = async (dataTransfer) => {
     const items = Array.from(dataTransfer?.items || []);
+    console.log(
+      'DataTransfer items',
+      items.map((i) => ({ kind: i.kind, type: i.type })),
+    );
+    console.log(
+      'DataTransfer files',
+      Array.from(dataTransfer?.files || []).map((f) => ({
+        name: f.name,
+        type: f.type,
+      })),
+    );
     const folders = [];
     const files = [];
     if (!items.length && dataTransfer?.files?.length) {
       files.push(...Array.from(dataTransfer.files));
+      console.log(
+        'Parsed items via files fallback',
+        files.map((f) => ({ name: f.name, type: f.type })),
+      );
       return { folders, files };
     }
     for (const item of items) {
-      if (item.kind !== 'file') continue;
+      if (item.kind !== 'file') {
+        console.log('Skipping non-file item', { kind: item.kind, type: item.type });
+        continue;
+      }
+      console.log('Processing item', { kind: item.kind, type: item.type });
       let handle = null;
       if (item.getAsFileSystemHandle) {
         try {
@@ -113,18 +132,38 @@ function App() {
         handle = item.webkitGetAsEntry();
       }
       if (handle && (handle.kind === 'directory' || handle.isDirectory)) {
+        console.log('Reading directory', handle.name);
         const dirFiles = await readAllFiles(handle);
         folders.push({ name: handle.name, files: dirFiles });
         files.push(...dirFiles);
+        console.log(
+          'Directory files',
+          dirFiles.map((f) => ({ name: f.name, type: f.type })),
+        );
       } else {
         const file = item.getAsFile
           ? item.getAsFile()
           : handle?.getFile
             ? await handle.getFile()
             : null;
-        if (file) files.push(file);
+        if (file) {
+          console.log('Adding file', { name: file.name, type: file.type });
+          files.push(file);
+        } else {
+          console.log('No file obtained from item');
+        }
       }
     }
+    console.log(
+      'Parsed items result',
+      {
+        folders: folders.map((f) => ({
+          name: f.name,
+          files: f.files.map((fl) => ({ name: fl.name, type: fl.type })),
+        })),
+        files: files.map((f) => ({ name: f.name, type: f.type })),
+      },
+    );
     return { folders, files };
   };
 

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -389,15 +389,33 @@ const FileManager = forwardRef(function FileManager({
   const parseDataTransferItems = async (dataTransfer) => {
     console.log('Parsing data transfer items');
     const items = Array.from(dataTransfer?.items || []);
+    console.log(
+      'DataTransfer items',
+      items.map((i) => ({ kind: i.kind, type: i.type })),
+    );
+    console.log(
+      'DataTransfer files',
+      Array.from(dataTransfer?.files || []).map((f) => ({
+        name: f.name,
+        type: f.type,
+      })),
+    );
     const folders = [];
     const files = [];
     if (!items.length && dataTransfer?.files?.length) {
       files.push(...Array.from(dataTransfer.files));
-      console.log('Parsed items', { folders, files });
+      console.log(
+        'Parsed items via files fallback',
+        files.map((f) => ({ name: f.name, type: f.type })),
+      );
       return { folders, files };
     }
     for (const item of items) {
-      if (item.kind !== 'file') continue;
+      if (item.kind !== 'file') {
+        console.log('Skipping non-file item', { kind: item.kind, type: item.type });
+        continue;
+      }
+      console.log('Processing item', { kind: item.kind, type: item.type });
       let handle = null;
       if (item.getAsFileSystemHandle) {
         try {
@@ -409,19 +427,38 @@ const FileManager = forwardRef(function FileManager({
         handle = item.webkitGetAsEntry();
       }
       if (handle && (handle.kind === 'directory' || handle.isDirectory)) {
+        console.log('Reading directory', handle.name);
         const dirFiles = await readAllFiles(handle);
         folders.push({ name: handle.name, files: dirFiles });
         files.push(...dirFiles);
+        console.log(
+          'Directory files',
+          dirFiles.map((f) => ({ name: f.name, type: f.type })),
+        );
       } else {
         const file = item.getAsFile
           ? item.getAsFile()
           : handle?.getFile
             ? await handle.getFile()
             : null;
-        if (file) files.push(file);
+        if (file) {
+          console.log('Adding file', { name: file.name, type: file.type });
+          files.push(file);
+        } else {
+          console.log('No file obtained from item');
+        }
       }
     }
-    console.log('Parsed items', { folders, files });
+    console.log(
+      'Parsed items result',
+      {
+        folders: folders.map((f) => ({
+          name: f.name,
+          files: f.files.map((fl) => ({ name: fl.name, type: fl.type })),
+        })),
+        files: files.map((f) => ({ name: f.name, type: f.type })),
+      },
+    );
     return { folders, files };
   };
 


### PR DESCRIPTION
## Summary
- log DataTransfer item kinds and file types during drag-and-drop
- expose files read from directories and fallback file lists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae0cc086b08321b446b589c3f9bdd4