### PR TITLE
Refactor drag helpers into shared module

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { toast } from 'react-hot-toast';
 import FileManager from './FileManager';
 import ScriptViewer from './ScriptViewer';
 import leaderLogo from './assets/LeaderPass-Logo-white.png';
+import { parseDataTransferItems } from './utils/dragHelpers.js';
 
 function App() {
   const [selectedScript, setSelectedScript] = useState(null);
@@ -58,113 +59,6 @@ function App() {
 
   const handleLeftDragOver = (e) => {
     e.preventDefault();
-  };
-  const readAllFiles = async (handle) => {
-    const files = [];
-    if (!handle) return files;
-    if (handle.kind === 'file' || handle.isFile) {
-      const file = handle.getFile
-        ? await handle.getFile()
-        : await new Promise((res, rej) => handle.file(res, rej));
-      files.push(file);
-    } else if (handle.kind === 'directory' || handle.isDirectory) {
-      if (handle.entries) {
-        for await (const [, child] of handle.entries()) {
-          files.push(...(await readAllFiles(child)));
-        }
-      } else if (handle.values) {
-        for await (const child of handle.values()) {
-          files.push(...(await readAllFiles(child)));
-        }
-      } else if (handle.createReader) {
-        const reader = handle.createReader();
-        const readEntries = () =>
-          new Promise((resolve) => reader.readEntries(resolve));
-        let entries = await readEntries();
-        while (entries.length) {
-          for (const entry of entries) {
-            files.push(...(await readAllFiles(entry)));
-          }
-          entries = await readEntries();
-        }
-      }
-    }
-    return files;
-  };
-
-  const parseDataTransferItems = async (dataTransfer) => {
-    const items = Array.from(dataTransfer?.items || []);
-    console.log(
-      'DataTransfer items',
-      items.map((i) => ({ kind: i.kind, type: i.type })),
-    );
-    console.log(
-      'DataTransfer files',
-      Array.from(dataTransfer?.files || []).map((f) => ({
-        name: f.name,
-        type: f.type,
-      })),
-    );
-    const folders = [];
-    const files = [];
-    if (!items.length && dataTransfer?.files?.length) {
-      files.push(...Array.from(dataTransfer.files));
-      console.log(
-        'Parsed items via files fallback',
-        files.map((f) => ({ name: f.name, type: f.type })),
-      );
-      return { folders, files };
-    }
-    for (const item of items) {
-      if (item.kind !== 'file') {
-        console.log('Skipping non-file item', { kind: item.kind, type: item.type });
-        continue;
-      }
-      console.log('Processing item', { kind: item.kind, type: item.type });
-      let handle = null;
-      if (item.getAsFileSystemHandle) {
-        try {
-          handle = await item.getAsFileSystemHandle();
-        } catch {
-          handle = null;
-        }
-      } else if (item.webkitGetAsEntry) {
-        handle = item.webkitGetAsEntry();
-      }
-      if (handle && (handle.kind === 'directory' || handle.isDirectory)) {
-        console.log('Reading directory', handle.name);
-        const dirFiles = await readAllFiles(handle);
-        folders.push({ name: handle.name, files: dirFiles });
-        files.push(...dirFiles);
-        console.log(
-          'Directory files',
-          dirFiles.map((f) => ({ name: f.name, type: f.type })),
-        );
-      } else {
-        const file = item.getAsFile
-          ? item.getAsFile()
-          : handle?.getFile
-            ? await handle.getFile()
-            : null;
-        if (file) {
-          console.log('Adding file', { name: file.name, type: file.type });
-          files.push(file);
-        } else {
-          console.log('No file obtained from item');
-        }
-      }
-    }
-    console.log(
-      'Parsed items result',
-      {
-        folders: folders.map((f) => ({
-          name: f.name,
-          files: f.files.map((fl) => ({ name: fl.name, type: fl.type })),
-        })),
-        files: files.map((f) => ({ name: f.name, type: f.type })),
-      },
-    );
-    return { folders, files };
   };
 
   const handleLeftDragEnter = (e) => {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -7,6 +7,7 @@ import {
 } from 'react';
 import ConfirmModal from './ConfirmModal.jsx';
 import { toast } from 'react-hot-toast';
+import { parseDataTransferItems } from './utils/dragHelpers.js';
 // The old project ActionMenu has been replaced with inline buttons
 
 function PencilIcon() {
@@ -353,114 +354,6 @@ const FileManager = forwardRef(function FileManager({
     e.dataTransfer.dropEffect = 'copy';
   };
 
-  const readAllFiles = async (handle) => {
-    const files = [];
-    if (!handle) return files;
-    if (handle.kind === 'file' || handle.isFile) {
-      const file = handle.getFile
-        ? await handle.getFile()
-        : await new Promise((res, rej) => handle.file(res, rej));
-      files.push(file);
-    } else if (handle.kind === 'directory' || handle.isDirectory) {
-      if (handle.entries) {
-        for await (const [, child] of handle.entries()) {
-          files.push(...(await readAllFiles(child)));
-        }
-      } else if (handle.values) {
-        for await (const child of handle.values()) {
-          files.push(...(await readAllFiles(child)));
-        }
-      } else if (handle.createReader) {
-        const reader = handle.createReader();
-        const readEntries = () =>
-          new Promise((resolve) => reader.readEntries(resolve));
-        let entries = await readEntries();
-        while (entries.length) {
-          for (const entry of entries) {
-            files.push(...(await readAllFiles(entry)));
-          }
-          entries = await readEntries();
-        }
-      }
-    }
-    return files;
-  };
-
-  const parseDataTransferItems = async (dataTransfer) => {
-    console.log('Parsing data transfer items');
-    const items = Array.from(dataTransfer?.items || []);
-    console.log(
-      'DataTransfer items',
-      items.map((i) => ({ kind: i.kind, type: i.type })),
-    );
-    console.log(
-      'DataTransfer files',
-      Array.from(dataTransfer?.files || []).map((f) => ({
-        name: f.name,
-        type: f.type,
-      })),
-    );
-    const folders = [];
-    const files = [];
-    if (!items.length && dataTransfer?.files?.length) {
-      files.push(...Array.from(dataTransfer.files));
-      console.log(
-        'Parsed items via files fallback',
-        files.map((f) => ({ name: f.name, type: f.type })),
-      );
-      return { folders, files };
-    }
-    for (const item of items) {
-      if (item.kind !== 'file') {
-        console.log('Skipping non-file item', { kind: item.kind, type: item.type });
-        continue;
-      }
-      console.log('Processing item', { kind: item.kind, type: item.type });
-      let handle = null;
-      if (item.getAsFileSystemHandle) {
-        try {
-          handle = await item.getAsFileSystemHandle();
-        } catch {
-          handle = null;
-        }
-      } else if (item.webkitGetAsEntry) {
-        handle = item.webkitGetAsEntry();
-      }
-      if (handle && (handle.kind === 'directory' || handle.isDirectory)) {
-        console.log('Reading directory', handle.name);
-        const dirFiles = await readAllFiles(handle);
-        folders.push({ name: handle.name, files: dirFiles });
-        files.push(...dirFiles);
-        console.log(
-          'Directory files',
-          dirFiles.map((f) => ({ name: f.name, type: f.type })),
-        );
-      } else {
-        const file = item.getAsFile
-          ? item.getAsFile()
-          : handle?.getFile
-            ? await handle.getFile()
-            : null;
-        if (file) {
-          console.log('Adding file', { name: file.name, type: file.type });
-          files.push(file);
-        } else {
-          console.log('No file obtained from item');
-        }
-      }
-    }
-    console.log(
-      'Parsed items result',
-      {
-        folders: folders.map((f) => ({
-          name: f.name,
-          files: f.files.map((fl) => ({ name: fl.name, type: fl.type })),
-        })),
-        files: files.map((f) => ({ name: f.name, type: f.type })),
-      },
-    );
-    return { folders, files };
-  };
 
   const getDroppedFolders = async (dataTransfer) => {
     const { folders } = await parseDataTransferItems(dataTransfer);

--- a/src/utils/dragHelpers.js
+++ b/src/utils/dragHelpers.js
@@ -1,0 +1,104 @@
+export const readAllFiles = async (handle) => {
+  const files = [];
+  if (!handle) return files;
+  if (handle.kind === 'file' || handle.isFile) {
+    const file = handle.getFile
+      ? await handle.getFile()
+      : await new Promise((res, rej) => handle.file(res, rej));
+    files.push(file);
+  } else if (handle.kind === 'directory' || handle.isDirectory) {
+    if (handle.entries) {
+      for await (const [, child] of handle.entries()) {
+        files.push(...(await readAllFiles(child)));
+      }
+    } else if (handle.values) {
+      for await (const child of handle.values()) {
+        files.push(...(await readAllFiles(child)));
+      }
+    } else if (handle.createReader) {
+      const reader = handle.createReader();
+      const readEntries = () => new Promise((resolve) => reader.readEntries(resolve));
+      let entries = await readEntries();
+      while (entries.length) {
+        for (const entry of entries) {
+          files.push(...(await readAllFiles(entry)));
+        }
+        entries = await readEntries();
+      }
+    }
+  }
+  return files;
+};
+
+export const parseDataTransferItems = async (dataTransfer) => {
+  console.log('Parsing data transfer items');
+  const items = Array.from(dataTransfer?.items || []);
+  console.log(
+    'DataTransfer items',
+    items.map((i) => ({ kind: i.kind, type: i.type })),
+  );
+  console.log(
+    'DataTransfer files',
+    Array.from(dataTransfer?.files || []).map((f) => ({ name: f.name, type: f.type })),
+  );
+  const folders = [];
+  const files = [];
+  if (!items.length && dataTransfer?.files?.length) {
+    files.push(...Array.from(dataTransfer.files));
+    console.log(
+      'Parsed items via files fallback',
+      files.map((f) => ({ name: f.name, type: f.type })),
+    );
+    return { folders, files };
+  }
+  for (const item of items) {
+    if (item.kind !== 'file') {
+      console.log('Skipping non-file item', { kind: item.kind, type: item.type });
+      continue;
+    }
+    console.log('Processing item', { kind: item.kind, type: item.type });
+    let handle = null;
+    if (item.getAsFileSystemHandle) {
+      try {
+        handle = await item.getAsFileSystemHandle();
+      } catch {
+        handle = null;
+      }
+    } else if (item.webkitGetAsEntry) {
+      handle = item.webkitGetAsEntry();
+    }
+    if (handle && (handle.kind === 'directory' || handle.isDirectory)) {
+      console.log('Reading directory', handle.name);
+      const dirFiles = await readAllFiles(handle);
+      folders.push({ name: handle.name, files: dirFiles });
+      files.push(...dirFiles);
+      console.log(
+        'Directory files',
+        dirFiles.map((f) => ({ name: f.name, type: f.type })),
+      );
+    } else {
+      const file = item.getAsFile
+        ? item.getAsFile()
+        : handle?.getFile
+          ? await handle.getFile()
+          : null;
+      if (file) {
+        console.log('Adding file', { name: file.name, type: file.type });
+        files.push(file);
+      } else {
+        console.log('No file obtained from item');
+      }
+    }
+  }
+  console.log(
+    'Parsed items result',
+    {
+      folders: folders.map((f) => ({
+        name: f.name,
+        files: f.files.map((fl) => ({ name: fl.name, type: fl.type })),
+      })),
+      files: files.map((f) => ({ name: f.name, type: f.type })),
+    },
+  );
+  return { folders, files };
+};

--- a/tests/drag-helpers.test.js
+++ b/tests/drag-helpers.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readAllFiles, parseDataTransferItems } from '../src/utils/dragHelpers.js';
+
+test('readAllFiles recursively collects files from directories', async () => {
+  const fileAHandle = {
+    kind: 'file',
+    async getFile() {
+      return { name: 'a.txt', type: 'text/plain' };
+    },
+  };
+  const fileBHandle = {
+    kind: 'file',
+    async getFile() {
+      return { name: 'b.txt', type: 'text/plain' };
+    },
+  };
+  const innerDirHandle = {
+    kind: 'directory',
+    async *entries() {
+      yield ['fileB', fileBHandle];
+    },
+  };
+  const rootDirHandle = {
+    kind: 'directory',
+    async *entries() {
+      yield ['fileA', fileAHandle];
+      yield ['inner', innerDirHandle];
+    },
+  };
+
+  const files = await readAllFiles(rootDirHandle);
+  assert.deepStrictEqual(
+    files.map((f) => f.name).sort(),
+    ['a.txt', 'b.txt'],
+  );
+});
+
+test('parseDataTransferItems returns folders and files', async () => {
+  const fileHandle = {
+    kind: 'file',
+    async getFile() {
+      return { name: 'inner.txt', type: 'text/plain' };
+    },
+  };
+  const dirHandle = {
+    kind: 'directory',
+    name: 'root',
+    async *entries() {
+      yield ['inner.txt', fileHandle];
+    },
+  };
+  const folderItem = {
+    kind: 'file',
+    type: '',
+    async getAsFileSystemHandle() {
+      return dirHandle;
+    },
+  };
+  const fileItem = {
+    kind: 'file',
+    type: 'text/plain',
+    getAsFile() {
+      return { name: 'loose.txt', type: 'text/plain' };
+    },
+  };
+  const dataTransfer = {
+    items: [folderItem, fileItem],
+    files: [],
+  };
+
+  const { folders, files } = await parseDataTransferItems(dataTransfer);
+  assert.strictEqual(folders.length, 1);
+  assert.strictEqual(folders[0].name, 'root');
+  assert.deepStrictEqual(
+    folders[0].files.map((f) => f.name),
+    ['inner.txt'],
+  );
+  assert.deepStrictEqual(
+    files.map((f) => f.name).sort(),
+    ['inner.txt', 'loose.txt'],
+  );
+});


### PR DESCRIPTION
## Summary
- extract readAllFiles and parseDataTransferItems into src/utils/dragHelpers.js
- update App and FileManager to reuse shared drag helpers
- add unit tests for drag helper functions

## Testing
- `npm run lint`
- `node --test tests/*.test.js tests/*.test.cjs`


------
https://chatgpt.com/codex/tasks/task_e_68ae1179d2f883218030c885c7e679d9