### PR TITLE
fix: clean drag helper tests

### DIFF
--- a/tests/drag-helpers.test.js
+++ b/tests/drag-helpers.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
-import { readAllFiles, parseDataTransferItems } from '../src/utils/dragHelpers.js';
+import fs from 'fs';
+import { readAllFiles, parseDataTransferItems, buildDocxPayload } from '../src/utils/dragHelpers.js';
 
 test('readAllFiles recursively collects files from directories', async () => {
   const fileAHandle = {
@@ -80,9 +81,8 @@ test('parseDataTransferItems returns folders and files', async () => {
     files.map((f) => f.name).sort(),
     ['inner.txt', 'loose.txt'],
   );
-=======
-import fs from 'fs';
-import { buildDocxPayload } from '../src/utils/dragHelpers.js';
+
+});
 
 function makeFile(name) {
   return {
@@ -104,7 +104,10 @@ test('App handleLeftDrop uses buildDocxPayload', () => {
   assert.ok(hasHelperCall);
 });
 
+
 test('FileManager handleDrop uses buildDocxPayload', () => {
   const source = fs.readFileSync('./src/FileManager.jsx', 'utf8');
   const hasHelperCall = /buildDocxPayload\(/.test(source);
   assert.ok(hasHelperCall);
+});
+


### PR DESCRIPTION
## Summary
- fix merge artifact in drag helpers test
- ensure tests import needed helpers and close correctly

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test` *(fails: The requested module '../src/utils/dragHelpers.js' does not provide an export named 'buildDocxPayload')*
- `npm run lint` *(fails: 'buildDocxPayload' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ae17205de483218acbe71b8bda2526