### PR TITLE
Add test script and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## Testing
+
+Run the test suite with:
+
+```bash
+npm test
+```
+
+This uses Node's built-in test runner (`node --test`).
+
 ## Electron API
 
 The preload script exposes an `electronAPI` object on `window` for renderer processes. Alongside other helpers, you can listen for live script updates with:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "electron-dev": "electron electron/main.cjs",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview",
     "start": "node scripts/bootstrap.mjs",
     "package": "node scripts/package.mjs"


### PR DESCRIPTION
## Summary
- add `node --test` script for running test suite
- document running tests via `npm test`

## Testing
- `npm test` *(fails: SyntaxError in tests/drag-helpers.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ae172429c883218cd060e1ab4acbbb