### PR TITLE
fix editor visibility for prompter

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -580,9 +580,8 @@ function Prompter() {
           className="editor-layer"
           style={{
             padding: 0,
-            position: isEditing ? 'relative' : 'absolute',
-            left: isEditing ? 0 : '-10000px',
-            top: 0,
+            visibility: isEditing ? 'visible' : 'hidden',
+            pointerEvents: isEditing ? 'auto' : 'none',
           }}
         >
           <TipTapEditor


### PR DESCRIPTION
## Summary
- hide editor layer using visibility/pointer-events instead of off-screen position to prevent duplicate mirror/scale lines

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7380b34708321af2b14655b038f8a