### PR TITLE
Add Ctrl/Cmd+F find bar to prompter and script editor

### DIFF
--- a/src/FindBar.css
+++ b/src/FindBar.css
@@ -1,0 +1,15 @@
+.find-bar {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: white;
+  padding: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  z-index: 1000;
+}
+
+.find-bar input {
+  outline: none;
+  border: none;
+}

--- a/src/FindBar.jsx
+++ b/src/FindBar.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react';
+import './FindBar.css';
+
+function FindBar({ onClose }) {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (query) {
+        window.find(query);
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose?.();
+    }
+  };
+
+  return (
+    <div className="find-bar">
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find..."
+      />
+    </div>
+  );
+}
+
+export default FindBar;

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef, useCallback } from 'react'
 import TipTapEditor from './TipTapEditor.jsx'
 import './Prompter.css'
 import './utils/disableLinks.css'
+import FindBar from './FindBar.jsx'
 
 const MARGIN_MIN = 0
 const MARGIN_MAX = 600
@@ -54,6 +55,7 @@ function Prompter() {
   const editorContainerRef = useRef(null)
   const [isEditing, setIsEditing] = useState(false)
   const updateTimeoutRef = useRef(null)
+  const [findOpen, setFindOpen] = useState(false)
 
   const handleEditorReady = (editor) => {
     editorRef.current = editor
@@ -156,6 +158,17 @@ function Prompter() {
     }
     container.addEventListener('scroll', syncScroll)
     return () => container.removeEventListener('scroll', syncScroll)
+  }, [])
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault()
+        setFindOpen(true)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
   }, [])
 
   useEffect(() => {
@@ -412,6 +425,7 @@ function Prompter() {
 
   return (
     <div className="prompter-wrapper">
+      {findOpen && <FindBar onClose={() => setFindOpen(false)} />}
       <div className="resize-handle top" onMouseDown={(e) => startResize(e, 'top')} />
       <div className="resize-handle bottom" onMouseDown={(e) => startResize(e, 'bottom')} />
       <div className="resize-handle left" onMouseDown={(e) => startResize(e, 'left')} />

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import TipTapEditor from './TipTapEditor.jsx';
 import { toast } from 'react-hot-toast';
 import './utils/disableLinks.css';
+import FindBar from './FindBar.jsx';
 
 function ScriptViewer({
   projectName,
@@ -19,6 +20,7 @@ function ScriptViewer({
   const [scriptHtml, setScriptHtml] = useState(null);
   const [loaded, setLoaded] = useState(false);
   const [showEditor, setShowEditor] = useState(false);
+  const [findOpen, setFindOpen] = useState(false);
   const saveTimeout = useRef(null);
   const scriptHtmlRef = useRef(null);
   const onSendRef = useRef(onSend);
@@ -63,6 +65,17 @@ function ScriptViewer({
     }
     return () => clearTimeout(timeout);
   }, [loaded]);
+
+  useEffect(() => {
+    const handleKey = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setFindOpen(true);
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
 
 useEffect(() => {
   let cancelled = false;
@@ -250,6 +263,7 @@ useEffect(() => {
 
   return (
     <div className="script-viewer">
+      {findOpen && <FindBar onClose={() => setFindOpen(false)} />}
       <div className="viewer-header">
         <div className="header-left">
           <h2 className="header-title">Script Viewer</h2>


### PR DESCRIPTION
## Summary
- Introduce reusable FindBar component that leverages `window.find` to search text
- Enable Ctrl/Cmd+F shortcut in Prompter and Script Viewer to toggle the bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7373e84048321a40a8ff8096d3dd8