### PR TITLE
Overlay editor layer to prevent scroll jump

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -180,7 +180,8 @@
 }
 
 .editor-layer {
-  position: relative;
+  position: absolute;
+  inset: 0;
   z-index: 1;
 }
 

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -594,8 +594,12 @@ function Prompter() {
           className="editor-layer"
           style={{
             padding: 0,
-            visibility: isEditing ? 'visible' : 'hidden',
+            display: isEditing ? 'block' : 'none',
             pointerEvents: isEditing ? 'auto' : 'none',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
           }}
         >
           <TipTapEditor


### PR DESCRIPTION
## Summary
- Overlay the editor using absolute positioning so it doesn't affect layout
- Swap visibility toggle for display and expand editor layer to full container

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b73a59a91083218d8048d7415faddc