### PR TITLE
feat: enhance find bar navigation

### DIFF
--- a/src/FindBar.css
+++ b/src/FindBar.css
@@ -13,3 +13,30 @@
   outline: none;
   border: none;
 }
+
+.find-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.find-controls button {
+  cursor: pointer;
+  background: #fff;
+  border: 1px solid #ccc;
+  padding: 0 4px;
+}
+
+.find-counter {
+  font-size: 12px;
+}
+
+.find-highlight {
+  background: yellow;
+}
+
+.find-highlight.active {
+  outline: 1px solid orange;
+}

--- a/src/FindBar.jsx
+++ b/src/FindBar.jsx
@@ -3,26 +3,127 @@ import './FindBar.css';
 
 function FindBar({ onClose }) {
   const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
   const inputRef = useRef(null);
+  const barRef = useRef(null);
+  const lastQueryRef = useRef('');
 
   useEffect(() => {
     inputRef.current?.focus();
-  }, []);
+    const handleClick = (e) => {
+      if (barRef.current && !barRef.current.contains(e.target)) {
+        clearHighlights();
+        onClose?.();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => {
+      document.removeEventListener('mousedown', handleClick);
+      clearHighlights();
+    };
+  }, [onClose]);
+
+  const clearHighlights = () => {
+    document.querySelectorAll('span.find-highlight').forEach((span) => {
+      const text = document.createTextNode(span.textContent);
+      span.replaceWith(text);
+    });
+  };
+
+  const highlightAll = (term) => {
+    clearHighlights();
+    if (!term) return [];
+    const regex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+    const matched = [];
+    const traverse = (node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const text = node.nodeValue;
+        const frag = document.createDocumentFragment();
+        let lastIndex = 0;
+        let match;
+        while ((match = regex.exec(text)) !== null) {
+          if (match.index > lastIndex) {
+            frag.appendChild(document.createTextNode(text.slice(lastIndex, match.index)));
+          }
+          const span = document.createElement('span');
+          span.className = 'find-highlight';
+          span.textContent = match[0];
+          frag.appendChild(span);
+          matched.push(span);
+          lastIndex = match.index + match[0].length;
+        }
+        if (lastIndex < text.length) {
+          frag.appendChild(document.createTextNode(text.slice(lastIndex)));
+        }
+        if (matched.length) node.replaceWith(frag);
+      } else if (
+        node.nodeType === Node.ELEMENT_NODE &&
+        node !== barRef.current &&
+        !barRef.current?.contains(node) &&
+        !['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(node.tagName)
+      ) {
+        Array.from(node.childNodes).forEach(traverse);
+      }
+    };
+    traverse(document.body);
+    return matched;
+  };
+
+  const goTo = (index) => {
+    if (!results.length) return;
+    const clamped = (index + results.length) % results.length;
+    results[currentIndex]?.classList.remove('active');
+    const el = results[clamped];
+    el.classList.add('active');
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    setCurrentIndex(clamped);
+  };
+
+  const handleSearch = () => {
+    const res = highlightAll(query);
+    setResults(res);
+    setCurrentIndex(0);
+    if (res.length) {
+      res[0].classList.add('active');
+      res[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  };
+
+  const handleNext = () => {
+    if (!results.length) return;
+    goTo(currentIndex + 1);
+    inputRef.current?.focus();
+  };
+
+  const handlePrev = () => {
+    if (!results.length) return;
+    goTo(currentIndex - 1);
+    inputRef.current?.focus();
+  };
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      if (query) {
-        window.find(query);
+      if (query && query === lastQueryRef.current) {
+        handleNext();
+      } else {
+        lastQueryRef.current = query;
+        handleSearch();
       }
     } else if (e.key === 'Escape') {
       e.preventDefault();
+      clearHighlights();
       onClose?.();
     }
   };
 
+  const counterText = results.length
+    ? `${currentIndex + 1} of ${results.length}`
+    : '0 of 0';
+
   return (
-    <div className="find-bar">
+    <div className="find-bar" ref={barRef}>
       <input
         ref={inputRef}
         value={query}
@@ -30,6 +131,11 @@ function FindBar({ onClose }) {
         onKeyDown={handleKeyDown}
         placeholder="Find..."
       />
+      <div className="find-controls">
+        <button onClick={handlePrev} disabled={!results.length}>&uarr;</button>
+        <span className="find-counter">{counterText}</span>
+        <button onClick={handleNext} disabled={!results.length}>&darr;</button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- highlight all matches and auto-scroll to each result
- add next/prev controls with result counter
- close find bar on escape or click away

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73cb2b46c83219e8c4145d86e6537