### PR TITLE
feat: add edit toggle for prompter

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -197,6 +197,19 @@
   border-radius: 4px;
 }
 
+.edit-toggle {
+  position: fixed;
+  bottom: var(--space-3);
+  right: var(--space-3);
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.6);
+  border: none;
+  color: #e0e0e0;
+  cursor: pointer;
+  padding: var(--space-2) var(--space-3);
+  border-radius: 4px;
+}
+
 .stop-button:hover {
   background-color: #dd5555;
 }

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -92,38 +92,19 @@ function Prompter() {
     }
   }, [])
 
-  const enterEdit = (e) => {
-    const { clientX, clientY } = e
-    setIsEditing(true)
-    setTimeout(() => {
-      const editor = editorRef.current
-      if (!editor) return
-      const pos = editor.view.posAtCoords({ left: clientX, top: clientY })
-      if (pos) {
-        editor.chain().focus().setTextSelection(pos.pos).run()
-      } else {
-        editor.commands.focus('end')
-      }
-    }, 0)
-  }
-
-  useEffect(() => {
-    if (!isEditing) return
-    const handleOutside = (e) => {
-      if (editorContainerRef.current?.contains(e.target)) return
+  const toggleEditing = () => {
+    if (isEditing) {
       flushEdit()
-      editorRef.current?.chain().setTextSelection({ from: 0, to: 0 }).run()
       editorRef.current?.commands.blur()
       setIsEditing(false)
+    } else {
+      setIsEditing(true)
+      setMainSettingsOpen(false)
+      setTimeout(() => {
+        editorRef.current?.commands.focus('end')
+      }, 0)
     }
-    const timeout = setTimeout(() => {
-      document.addEventListener('mousedown', handleOutside)
-    }, 50)
-    return () => {
-      clearTimeout(timeout)
-      document.removeEventListener('mousedown', handleOutside)
-    }
-  }, [isEditing, flushEdit])
+  }
 
   const resetDefaults = () => {
     setAutoscroll(DEFAULT_SETTINGS.autoscroll)
@@ -436,7 +417,8 @@ function Prompter() {
       <div className="resize-handle bottom-right" onMouseDown={(e) => startResize(e, 'bottom-right')} />
         <button
           className={`main-settings-toggle ${mainSettingsOpen ? 'open' : ''}`}
-          onClick={() => setMainSettingsOpen(!mainSettingsOpen)}
+          onClick={() => !isEditing && setMainSettingsOpen(!mainSettingsOpen)}
+          disabled={isEditing}
         >
           {mainSettingsOpen ? '←' : '→'}
         </button>
@@ -581,7 +563,6 @@ function Prompter() {
           <div
             key="render"
             className="script-output disable-links"
-            onClick={enterEdit}
             dangerouslySetInnerHTML={{
               __html: notecardMode ? slides[currentSlide] || '' : content,
             }}
@@ -635,6 +616,9 @@ function Prompter() {
           </button>
         </div>
       )}
+      <button className="edit-toggle" onClick={toggleEditing}>
+        {isEditing ? 'EDITING...' : 'EDIT'}
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add bottom-right Edit button to toggle ProseMirror editing and lock settings sidebar
- close settings panel while editing and render updated text when toggled off
- style edit toggle for fixed positioning

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74612fcec8321a4e86331882ae076