### PR TITLE
Improve find bar visibility and script editor autoscroll

### DIFF
--- a/src/FindBar.css
+++ b/src/FindBar.css
@@ -1,32 +1,51 @@
 .find-bar {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  background: white;
-  padding: 4px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  top: var(--space-3);
+  right: var(--space-3);
   z-index: 1000;
+  background: #333;
+  color: #e0e0e0;
+  padding: var(--space-2);
+  border: 1px solid #555;
+  border-radius: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
 .find-bar input {
   outline: none;
-  border: none;
+  border: 1px solid #555;
+  background: #222;
+  color: #e0e0e0;
+  border-radius: 4px;
+  padding: 2px 4px;
 }
 
 .find-controls {
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
-  margin-top: 4px;
+  gap: var(--space-2);
 }
 
 .find-controls button {
   cursor: pointer;
-  background: #fff;
-  border: 1px solid #ccc;
-  padding: 0 4px;
+  background: #444;
+  border: 1px solid #555;
+  color: #e0e0e0;
+  padding: 0 6px;
+  border-radius: 4px;
+}
+
+.find-controls button:hover:not(:disabled) {
+  background: #555;
+}
+
+.find-controls button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .find-counter {
@@ -35,6 +54,7 @@
 
 .find-highlight {
   background: yellow;
+  color: #000;
 }
 
 .find-highlight.active {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -425,7 +425,12 @@ function Prompter() {
 
   return (
     <div className="prompter-wrapper">
-      {findOpen && <FindBar onClose={() => setFindOpen(false)} />}
+      {findOpen && (
+        <FindBar
+          onClose={() => setFindOpen(false)}
+          containerRef={containerRef}
+        />
+      )}
       <div className="resize-handle top" onMouseDown={(e) => startResize(e, 'top')} />
       <div className="resize-handle bottom" onMouseDown={(e) => startResize(e, 'bottom')} />
       <div className="resize-handle left" onMouseDown={(e) => startResize(e, 'left')} />

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -30,6 +30,7 @@ function ScriptViewer({
   const onCloseViewerRef = useRef(onCloseViewer);
   const projectNameRef = useRef(projectName);
   const scriptNameRef = useRef(scriptName);
+  const contentRef = useRef(null);
 
   useEffect(() => {
     onSendRef.current = onSend;
@@ -263,7 +264,12 @@ useEffect(() => {
 
   return (
     <div className="script-viewer">
-      {findOpen && <FindBar onClose={() => setFindOpen(false)} />}
+      {findOpen && (
+        <FindBar
+          onClose={() => setFindOpen(false)}
+          containerRef={contentRef}
+        />
+      )}
       <div className="viewer-header">
         <div className="header-left">
           <h2 className="header-title">Script Viewer</h2>
@@ -276,7 +282,7 @@ useEffect(() => {
           </div>
         </div>
       )}
-      <div className={viewerClass}>
+      <div className={viewerClass} ref={contentRef}>
         {showEditor && (
           <TipTapEditor initialHtml={scriptHtml || ''} onUpdate={handleEdit} />
         )}


### PR DESCRIPTION
## Summary
- scope find bar searching and navigation to the active window so prompter and script editor operate independently
- wire prompter and script editor containers into find bar for in-place scrolling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b73e8e5320832182e84e42d19c2f25