### PR TITLE
Style prompter edit toggle

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -202,12 +202,21 @@
   bottom: var(--space-3);
   right: var(--space-3);
   z-index: 1000;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--accent-color);
   border: none;
-  color: #e0e0e0;
+  color: #1e1e1e;
   cursor: pointer;
   padding: var(--space-2) var(--space-3);
-  border-radius: 4px;
+  border-radius: 6px;
+}
+
+.edit-toggle.editing {
+  background: #bb4444;
+  color: #fff;
+}
+
+.edit-toggle.editing:hover {
+  background: #dd5555;
 }
 
 .stop-button:hover {

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -616,8 +616,11 @@ function Prompter() {
           </button>
         </div>
       )}
-      <button className="edit-toggle" onClick={toggleEditing}>
-        {isEditing ? 'EDITING...' : 'EDIT'}
+      <button
+        className={`edit-toggle${isEditing ? ' editing' : ''}`}
+        onClick={toggleEditing}
+      >
+        {isEditing ? 'STOP EDITING' : 'EDIT'}
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Style prompter edit toggle using brand gold and rounded corners
- Turn edit button red with STOP EDITING label during active editing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b749872d048321a9aba3afd1f40b3c