### PR TITLE
Align editor overlay with display margins

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -574,7 +574,8 @@ function Prompter() {
           ref={editorContainerRef}
           className="editor-layer"
           style={{
-            padding: 0,
+            padding: `2rem ${margin}px`,
+            boxSizing: 'border-box',
             display: isEditing ? 'block' : 'none',
             pointerEvents: isEditing ? 'auto' : 'none',
             top: 0,


### PR DESCRIPTION
## Summary
- Match `editor-layer` padding to outer prompter container and use `border-box` so editor overlay mirrors margins

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b74af2620c8321b160b68900860816