### PR TITLE
Focus editor near visible region when toggling edit mode

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -101,7 +101,16 @@ function Prompter() {
       setIsEditing(true)
       setMainSettingsOpen(false)
       setTimeout(() => {
-        editorRef.current?.commands.focus('end')
+        const container = containerRef.current
+        const pos = editorRef.current?.view.posAtCoords({
+          left: container.clientLeft + 1,
+          top: container.scrollTop + 1,
+        })
+        editorRef.current
+          ?.chain()
+          .focus()
+          .setTextSelection(pos?.pos ?? 0)
+          .run()
       }, 0)
     }
   }


### PR DESCRIPTION
## Summary
- focus editor near visible region when toggling edit mode instead of jumping to end

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74af38fa48321bde3785012d50b6f