### PR TITLE
Pause auto-scroll while editing in prompter

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -332,7 +332,7 @@ function Prompter() {
 
 
   useEffect(() => {
-    if (!autoscroll || notecardMode) return undefined
+    if (!autoscroll || notecardMode || isEditing) return undefined
     let requestId
     const step = () => {
       if (containerRef.current) {
@@ -342,7 +342,7 @@ function Prompter() {
     }
     requestId = requestAnimationFrame(step)
     return () => cancelAnimationFrame(requestId)
-  }, [autoscroll, speed, notecardMode])
+  }, [autoscroll, speed, notecardMode, isEditing])
 
   // Generate notecard slides when layout-related values change
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stop auto-scroll when editing mode is active so text stays put during edits

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74dc1c30c83218f82fb1459cfa29b