### PR TITLE
Use gear tab for prompter settings panel

### DIFF
--- a/src/Prompter.css
+++ b/src/Prompter.css
@@ -147,11 +147,16 @@
   left: 0;
   z-index: 1000;
   background: rgba(0, 0, 0, 0.6);
-  border: none;
+  border: 1px solid #e0e0e0;
+  border-left: none;
   color: #e0e0e0;
   cursor: pointer;
-  padding: var(--space-2);
-  border-radius: 0 4px 4px 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0 8px 8px 0;
   transform: translateX(0);
   transition: transform 0.3s ease-in-out;
 }

--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -428,8 +428,9 @@ function Prompter() {
           className={`main-settings-toggle ${mainSettingsOpen ? 'open' : ''}`}
           onClick={() => !isEditing && setMainSettingsOpen(!mainSettingsOpen)}
           disabled={isEditing}
+          aria-label="Settings"
         >
-          {mainSettingsOpen ? '←' : '→'}
+          ⚙
         </button>
         <div className={`main-settings ${mainSettingsOpen ? 'open' : ''}`}>
         <button


### PR DESCRIPTION
## Summary
- Replace prompter sidebar arrow with a gear icon toggle
- Style the toggle as a tab with fixed size and border

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b74f6d6704832196d0e791f791a068