### PR TITLE
feat: delay remote updates during editing

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -54,8 +54,18 @@ function Prompter() {
   const editorRef = useRef(null)
   const editorContainerRef = useRef(null)
   const [isEditing, setIsEditing] = useState(false)
+  const isEditingRef = useRef(isEditing)
+  const pendingRemoteHtmlRef = useRef(null)
   const updateTimeoutRef = useRef(null)
   const [findOpen, setFindOpen] = useState(false)
+
+  useEffect(() => {
+    isEditingRef.current = isEditing
+    if (!isEditing && pendingRemoteHtmlRef.current !== null) {
+      setContent(pendingRemoteHtmlRef.current)
+      pendingRemoteHtmlRef.current = null
+    }
+  }, [isEditing])
 
   const handleEditorReady = (editor) => {
     editorRef.current = editor
@@ -303,6 +313,10 @@ function Prompter() {
       setProjectName(data.project || null)
     }
     const handleUpdated = (html) => {
+      if (isEditingRef.current) {
+        pendingRemoteHtmlRef.current = html
+        return
+      }
       setContent(html)
     }
 


### PR DESCRIPTION
## Summary
- avoid overwriting local changes by ignoring remote script updates while editing
- cache latest remote HTML and apply it after editing ends

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b751b651f4832197751be354b78215