### PR TITLE
Flush edits when window loses focus

### DIFF
--- a/src/Prompter.jsx
+++ b/src/Prompter.jsx
@@ -102,6 +102,17 @@ function Prompter() {
     }
   }, [])
 
+  const handleBlur = useCallback(() => {
+    if (!isEditingRef.current) return
+    flushEdit()
+    setIsEditing(false)
+  }, [flushEdit])
+
+  useEffect(() => {
+    window.addEventListener('blur', handleBlur)
+    return () => window.removeEventListener('blur', handleBlur)
+  }, [handleBlur])
+
   const toggleEditing = () => {
     if (isEditing) {
       flushEdit()


### PR DESCRIPTION
## Summary
- Flush pending editor changes when the window blurs
- Stop editing mode on blur

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7599e5cf88321b06cf7177aecd1fe