### PR TITLE
Fix splash screen logo path

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -1,8 +1,9 @@
+import logo from '/logos/LP_white.png';
 import './SplashScreen.css';
 
 const SplashScreen = () => (
   <div className="splash-screen">
-    <img src="/logos/LP_white.png" alt="LeaderPrompt" />
+    <img src={logo} alt="LeaderPrompt" />
   </div>
 );
 


### PR DESCRIPTION
## Summary
- import splash logo so Vite rewrites path relative to bundled files

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b78ca277cc8321b52e133ac687dff1