### PR TITLE
Limit context menu size to viewport

### DIFF
--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -36,6 +36,9 @@
   padding: 4px;
   display: flex;
   gap: 4px;
+  width: 20vw;
+  max-height: 50vh;
+  overflow-y: auto;
 }
 
 .context-menu.format {


### PR DESCRIPTION
## Summary
- constrain context menu width and height to a percentage of the window using CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b845cd4938832197bdd1252c912096