### PR TITLE
feat: add input fields to API key prompt

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -650,6 +650,9 @@ app.whenReady().then(async () => {
           cancelId: 1,
           title: 'OpenAI API Key',
           message: 'Enter your OpenAI API key',
+          // provide an input for the API key
+          inputLabel: 'API Key',
+          inputPlaceholder: 'sk-...',
           // electron 37+ supports input field on message boxes
           inputType: 'password',
         },


### PR DESCRIPTION
## Summary
- ensure API key prompt includes a password field with label and placeholder for entering key

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8469b5fd483218302c09bde33eb79