### PR TITLE
style: limit sub menus to viewport

### DIFF
--- a/src/TipTapEditor.css
+++ b/src/TipTapEditor.css
@@ -37,6 +37,9 @@
   display: flex;
   gap: 4px;
   font-size: 0.875rem;
+  width: 20vw;
+  max-height: 50vh;
+  overflow-y: auto;
 }
 
 .context-menu.format {
@@ -83,9 +86,12 @@
   color: #e0e0e0;
   border: 1px solid #555;
   border-radius: 4px;
-  width: 220px;
+  width: min(220px, 20vw);
   display: flex;
   flex-direction: column;
+  font-size: 0.875rem;
+  max-height: 50vh;
+  overflow-y: auto;
 }
 
 .ai-rescript-panel .ai-header {


### PR DESCRIPTION
## Summary
- prevent context menu submenus from overflowing viewport
- apply same width/height constraints to AI rewrite panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8482b67548321874a7c388614c3bd