### PR TITLE
perf: reduce renders and sorting cost

### DIFF
--- a/src/ActionMenu.jsx
+++ b/src/ActionMenu.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback, memo } from 'react';
 
 function ActionMenu({ actions }) {
   const [open, setOpen] = useState(false);
@@ -14,10 +14,13 @@ function ActionMenu({ actions }) {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [open]);
 
-  const handleAction = (fn) => {
-    fn();
-    setOpen(false);
-  };
+  const handleAction = useCallback(
+    (fn) => {
+      fn();
+      setOpen(false);
+    },
+    [],
+  );
 
   return (
     <div className="menu-container" ref={menuRef}>
@@ -35,4 +38,4 @@ function ActionMenu({ actions }) {
   );
 }
 
-export default ActionMenu;
+export default memo(ActionMenu);

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useImperativeHandle,
   useRef,
+  useMemo,
 } from 'react';
 import ConfirmModal from './ConfirmModal.jsx';
 import { toast } from 'react-hot-toast';
@@ -90,6 +91,22 @@ const FileManager = forwardRef(function FileManager({
   const [hoverIndex, setHoverIndex] = useState(null);
   const [hoverProject, setHoverProject] = useState(null);
   const [rootDrag, setRootDrag] = useState(false);
+
+  const sortedScripts = useMemo(() => {
+    const result = {};
+    projects.forEach((project) => {
+      let scripts = project.scripts;
+      if (sortBy === 'name') {
+        scripts = [...scripts].sort((a, b) => a.name.localeCompare(b.name));
+      } else if (sortBy === 'date') {
+        scripts = [...scripts].sort(
+          (a, b) => (a.added || 0) - (b.added || 0),
+        );
+      }
+      result[project.name] = scripts;
+    });
+    return result;
+  }, [projects, sortBy]);
 
 
   useEffect(() => {
@@ -664,18 +681,7 @@ const FileManager = forwardRef(function FileManager({
               )}
             </div>
             <ul className={collapsed[project.name] ? 'collapsed' : ''}>
-              {project.scripts
-                .slice()
-                .sort((a, b) => {
-                  if (sortBy === 'name') {
-                    return a.name.localeCompare(b.name);
-                  }
-                  if (sortBy === 'date') {
-                    return (a.added || 0) - (b.added || 0);
-                  }
-                  return 0;
-                })
-                .map((script) => {
+              {sortedScripts[project.name].map((script) => {
                   const index = project.scripts.findIndex((s) => s.name === script.name);
                   const scriptName = script.name;
                   const isPrompting =

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -116,30 +116,33 @@ useEffect(() => {
   };
 }, [projectName, scriptName]);
 
-  const handleEdit = (html) => {
-    setScriptHtml(html);
-    scriptHtmlRef.current = html;
-    if (projectName && scriptName) {
-      if (saveTimeout.current) {
-        clearTimeout(saveTimeout.current);
+  const handleEdit = useCallback(
+    (html) => {
+      setScriptHtml(html);
+      scriptHtmlRef.current = html;
+      if (projectName && scriptName) {
+        if (saveTimeout.current) {
+          clearTimeout(saveTimeout.current);
+        }
+        saveTimeout.current = setTimeout(() => {
+          if (!window.electronAPI?.saveScript) {
+            console.error('electronAPI unavailable');
+            return;
+          }
+          window.electronAPI.saveScript(projectName, scriptName, html);
+          saveTimeout.current = null;
+        }, 300);
       }
-      saveTimeout.current = setTimeout(() => {
-        if (!window.electronAPI?.saveScript) {
+      if (projectName === loadedProject && scriptName === loadedScript) {
+        if (!window.electronAPI?.sendUpdatedScript) {
           console.error('electronAPI unavailable');
           return;
         }
-        window.electronAPI.saveScript(projectName, scriptName, html);
-        saveTimeout.current = null;
-      }, 300);
-    }
-    if (projectName === loadedProject && scriptName === loadedScript) {
-      if (!window.electronAPI?.sendUpdatedScript) {
-        console.error('electronAPI unavailable');
-        return;
+        window.electronAPI.sendUpdatedScript(html);
       }
-      window.electronAPI.sendUpdatedScript(html);
-    }
-  };
+    },
+    [projectName, scriptName, loadedProject, loadedScript],
+  );
 
   useEffect(() => {
     if (!window.electronAPI?.onScriptUpdated || !window.electronAPI?.saveScript) {


### PR DESCRIPTION
## Summary
- memoize action menu callbacks and export to avoid unnecessary re-renders
- pre-compute sorted script lists to avoid sorting on every render
- memoize ScriptViewer's edit handler to prevent needless TipTap updates

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b84ef49bcc832190eaf273751a20e5