### PR TITLE
Debounce project settings saves and async file IO

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -376,11 +376,14 @@ function readProjectSettings(projectName) {
   }
 }
 
-function writeProjectSettings(projectName, settings) {
+async function writeProjectSettings(projectName, settings) {
   const settingsPath = getProjectSettingsPath(projectName);
   try {
-    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+    await fs.promises.mkdir(path.dirname(settingsPath), { recursive: true });
+    await fs.promises.writeFile(
+      settingsPath,
+      JSON.stringify(settings, null, 2),
+    );
     return true;
   } catch (err) {
     error('Failed to write project settings:', err);


### PR DESCRIPTION
## Summary
- avoid blocking the main thread by using async fs methods when writing project settings
- debounce Prompter settings saves and flush before window closes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8548de82083218ac84e5facfac840