### PR TITLE
Keep prompter window alive when closing

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -573,13 +573,18 @@ app.whenReady().then(async () => {
 
   ipcMain.on('close-prompter', () => {
     if (prompterWindow && !prompterWindow.isDestroyed()) {
+      prompterWindow.hide();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('prompter-closed');
+      }
+      log('Prompter window hidden');
+    }
+  });
+
+  ipcMain.on('destroy-prompter', () => {
+    if (prompterWindow && !prompterWindow.isDestroyed()) {
       prompterWindow.close();
     }
-    prompterWindow = null;
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('prompter-closed');
-    }
-    log('Prompter window closed');
   });
 
   ipcMain.on('minimize-prompter', () => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -78,6 +78,7 @@ const api = {
     ipcRenderer.send('set-prompter-always-on-top', flag),
 
   closePrompter: () => ipcRenderer.send('close-prompter'),
+  destroyPrompter: () => ipcRenderer.send('destroy-prompter'),
   minimizePrompter: () => ipcRenderer.send('minimize-prompter'),
 
   onPrompterClosed: (callback) => {

--- a/tests/prompter-bridge.test.cjs
+++ b/tests/prompter-bridge.test.cjs
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const Module = require('module');
+
+function loadPreload() {
+  let exposed;
+  const ipcRenderer = {
+    invoke: (...args) => {
+      loadPreload.invokeArgs = args;
+      return Promise.resolve(true);
+    },
+    on: () => {},
+    send: (...args) => {
+      loadPreload.sendArgs = args;
+    },
+  };
+  const contextBridge = {
+    exposeInMainWorld: (key, api) => {
+      exposed = api;
+    },
+  };
+  const electronPath = require.resolve('electron');
+  const original = Module._cache[electronPath];
+  Module._cache[electronPath] = { exports: { ipcRenderer, contextBridge } };
+  delete require.cache[require.resolve('../electron/preload.cjs')];
+  global.window = {};
+  require('../electron/preload.cjs');
+  if (original) {
+    Module._cache[electronPath] = original;
+  } else {
+    delete Module._cache[electronPath];
+  }
+  return exposed;
+}
+
+test('closePrompter sends channel', () => {
+  const api = loadPreload();
+  api.closePrompter();
+  const args = loadPreload.sendArgs;
+  assert.strictEqual(args[0], 'close-prompter');
+  delete global.window;
+});
+
+test('destroyPrompter sends channel', () => {
+  const api = loadPreload();
+  api.destroyPrompter();
+  const args = loadPreload.sendArgs;
+  assert.strictEqual(args[0], 'destroy-prompter');
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- Hide prompter window on `close-prompter` instead of destroying it
- Allow explicitly destroying prompter with `destroy-prompter` event and preload bridge
- Test preload bridges for prompter window control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8548ee0388321ac42b37e5af2ae9d