### PR TITLE
Add bottom margin to subpage headers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -77,7 +77,7 @@ body {
 }
 
 .file-manager-header .header-title {
-  margin: 0;
+  margin-top: 0;
 }
 
 .file-manager-header .header-left {

--- a/src/FileManager.jsx
+++ b/src/FileManager.jsx
@@ -578,7 +578,7 @@ const FileManager = forwardRef(function FileManager({
     <div className="file-manager">
       <div className="file-manager-header">
         <div className="header-left">
-          <h2 className="header-title">Projects</h2>
+          <h2 className="header-title mb-2">Projects</h2>
         </div>
       </div>
       <div className="header-buttons">

--- a/src/ScriptViewer.jsx
+++ b/src/ScriptViewer.jsx
@@ -269,7 +269,7 @@ useEffect(() => {
       {findOpen && <FindBar onClose={() => setFindOpen(false)} />}
       <div className="viewer-header">
         <div className="header-left">
-          <h2 className="header-title">Script Viewer</h2>
+          <h2 className="header-title mb-2">Script Viewer</h2>
         </div>
       </div>
       {loaded && scriptName && (

--- a/src/index.css
+++ b/src/index.css
@@ -107,8 +107,12 @@ button:focus-visible {
 }
 
 .header-title {
-  margin: 0;
+  margin-top: 0;
   font-size: 1.5rem;
+}
+
+.mb-2 {
+  margin-bottom: var(--space-2);
 }
 
 @media (prefers-color-scheme: light) {


### PR DESCRIPTION
## Summary
- Set consistent bottom spacing on subpage headers via `mb-2`
- Update styles to support new header margin utility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f26f374c8321803a8c9464b85f0a